### PR TITLE
perf(gas): optimize stage per wallet limits gas

### DIFF
--- a/contracts/IERC721M.sol
+++ b/contracts/IERC721M.sol
@@ -79,7 +79,7 @@ interface IERC721M is IERC721AQueryable {
         view
         returns (
             MintStageInfo memory,
-            uint32,
+            uint16,
             uint256
         );
 


### PR DESCRIPTION
- saves every minter 20k of gas (@ 50 gwei this is ~$2, @ 100 gwei this is ~$4)
- pack into aux on the erc721a ownership storage
- ⚠️ caveat ⚠️: limits # of stages to 4 (or 8 if max limit per wallet of 255 is acceptable)

### gas averages before optimization

![image](https://github.com/magicoss/erc721m/assets/3287496/13d4731e-d819-4d05-8142-d19fd999252b)

### gas averages post optimization

![image](https://github.com/magicoss/erc721m/assets/3287496/85bc53b3-f720-4a66-aa17-f37d5a647d05)
