### PR TITLE
Minting with ERC-20 payment

### DIFF
--- a/contracts/BucketAuction.sol
+++ b/contracts/BucketAuction.sol
@@ -42,7 +42,9 @@ contract BucketAuction is IBucketAuction, ERC721M {
             globalWalletLimit,
             cosigner,
             /* timestampExpirySeconds= */
-            300
+            300,
+            /* mintCurrency= */
+            address(0)
         )
     {
         _claimable = false;

--- a/contracts/DutchAuction.sol
+++ b/contracts/DutchAuction.sol
@@ -35,7 +35,9 @@ contract DutchAuction is IDutchAuction, ERC721M {
             globalWalletLimit,
             cosigner,
             /* timestampExpirySeconds= */
-            300
+            300,
+            /* mintCurrency= */
+            address(0)
         )
     {
         _refundable = refundable;

--- a/contracts/ERC721M.sol
+++ b/contracts/ERC721M.sol
@@ -375,16 +375,8 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
     /**
      * @dev Returns mint currency address.
      */
-    function getMintCurrency() external view returns (address) {
+    function getMintCurrency() external view override returns (address) {
         return _mintCurrency;
-    }
-
-    /**
-     * @dev Sets the mint currency used for payment.
-     */
-    function setMintCurrency(address mintCurrency) external onlyOwner {
-        _mintCurrency = mintCurrency;
-        emit SetMintCurrency(mintCurrency);
     }
 
     /**
@@ -520,10 +512,10 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
     /**
      * @dev Withdraws ERC-20 funds by owner.
      */
-    function withdrawERC20(address mintCurrency) external onlyOwner {
-        uint256 value = IERC20(mintCurrency).balanceOf(address(this));
-        IERC20(mintCurrency).safeTransfer(msg.sender, value);
-        emit WithdrawERC20(mintCurrency, value);
+    function withdrawERC20() external onlyOwner {
+        uint256 value = IERC20(_mintCurrency).balanceOf(address(this));
+        IERC20(_mintCurrency).safeTransfer(msg.sender, value);
+        emit WithdrawERC20(_mintCurrency, value);
     }
 
     /**

--- a/contracts/ERC721M.sol
+++ b/contracts/ERC721M.sol
@@ -513,6 +513,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
      * @dev Withdraws ERC-20 funds by owner.
      */
     function withdrawERC20() external onlyOwner {
+        if (_mintCurrency == address(0)) revert WrongMintCurrency();
         uint256 value = IERC20(_mintCurrency).balanceOf(address(this));
         IERC20(_mintCurrency).safeTransfer(msg.sender, value);
         emit WithdrawERC20(_mintCurrency, value);

--- a/contracts/ERC721M.sol
+++ b/contracts/ERC721M.sol
@@ -7,6 +7,7 @@ import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
 import "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "erc721a/contracts/extensions/ERC721AQueryable.sol";
 import "./IERC721M.sol";
 
@@ -22,6 +23,7 @@ import "./IERC721M.sol";
  */
 contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
     using ECDSA for bytes32;
+    using SafeERC20 for IERC20;
 
     // Whether this contract is mintable.
     bool private _mintable;
@@ -60,6 +62,9 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
     // Minted count per stage.
     mapping(uint256 => uint256) private _stageMintedCounts;
 
+    // Address of ERC-20 token used to pay for minting. If 0 address, use native currency.
+    address public mintCurrency;
+
     constructor(
         string memory collectionName,
         string memory collectionSymbol,
@@ -78,6 +83,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
         _tokenURISuffix = tokenURISuffix;
         _cosigner = cosigner; // ethers.constants.AddressZero for no cosigning
         _timestampExpirySeconds = timestampExpirySeconds;
+        mintCurrency = address(0);
     }
 
     /**
@@ -366,6 +372,14 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
     }
 
     /**
+     * @dev Sets the mint currency used for payment.
+     */
+    function setMintCurrency(address newMintCurrency) external onlyOwner {
+        mintCurrency = newMintCurrency;
+        emit SetMintCurrency(mintCurrency);
+    }
+
+    /**
      * @dev Mints token(s).
      *
      * qty - number of tokens to mint
@@ -429,8 +443,8 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
 
         stage = _mintStages[activeStage];
 
-        // Check value
-        if (msg.value < stage.price * qty) revert NotEnoughValue();
+        // Check value if minting with ETH
+        if (mintCurrency == address(0) && msg.value < stage.price * qty) revert NotEnoughValue();
 
         // Check stage supply if applicable
         if (stage.maxStageSupply > 0) {
@@ -462,6 +476,10 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
             ) revert InvalidProof();
         }
 
+        if (mintCurrency != address(0)) {
+            IERC20(mintCurrency).safeTransferFrom(msg.sender, address(this), stage.price * qty);
+        }
+
         _stageMintedCountsPerWallet[activeStage][to] += qty;
         _stageMintedCounts[activeStage] += qty;
         _safeMint(to, qty);
@@ -489,6 +507,15 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
         (bool success, ) = msg.sender.call{value: value}("");
         if (!success) revert WithdrawFailed();
         emit Withdraw(value);
+    }
+
+    /**
+     * @dev Withdraws ERC-20 funds by owner.
+     */
+    function withdrawERC20(address mintCurrencyWithdrawn) external onlyOwner {
+        uint256 value = IERC20(mintCurrencyWithdrawn).balanceOf(address(this));
+        IERC20(mintCurrencyWithdrawn).safeTransfer(msg.sender, value);
+        emit WithdrawERC20(mintCurrencyWithdrawn, value);
     }
 
     /**

--- a/contracts/ERC721MAutoApprover.sol
+++ b/contracts/ERC721MAutoApprover.sol
@@ -17,6 +17,7 @@ contract ERC721MAutoApprover is ERC721M {
         uint256 globalWalletLimit,
         address cosigner,
         uint64 timestampExpirySeconds,
+        address mintCurrency,
         address autoApproveAddress
     )
         ERC721M(
@@ -26,7 +27,8 @@ contract ERC721MAutoApprover is ERC721M {
             maxMintableSupply,
             globalWalletLimit,
             cosigner,
-            timestampExpirySeconds
+            timestampExpirySeconds,
+            mintCurrency
         )
     {
         _autoApproveAddress = autoApproveAddress;

--- a/contracts/ERC721MIncreasableOperatorFilterer.sol
+++ b/contracts/ERC721MIncreasableOperatorFilterer.sol
@@ -14,7 +14,8 @@ contract ERC721MIncreasableOperatorFilterer is ERC721MIncreasableSupply, Default
         uint256 maxMintableSupply,
         uint256 globalWalletLimit,
         address cosigner,
-        uint64 timestampExpirySeconds
+        uint64 timestampExpirySeconds,
+        address mintCurrency
     )
         ERC721MIncreasableSupply(
             collectionName,
@@ -23,7 +24,8 @@ contract ERC721MIncreasableOperatorFilterer is ERC721MIncreasableSupply, Default
             maxMintableSupply,
             globalWalletLimit,
             cosigner,
-            timestampExpirySeconds
+            timestampExpirySeconds,
+            mintCurrency
         )
     {}
 

--- a/contracts/ERC721MIncreasableSupply.sol
+++ b/contracts/ERC721MIncreasableSupply.sol
@@ -17,7 +17,8 @@ contract ERC721MIncreasableSupply is ERC721M {
         uint256 maxMintableSupply,
         uint256 globalWalletLimit,
         address cosigner,
-        uint64 timestampExpirySeconds
+        uint64 timestampExpirySeconds,
+        address mintCurrency
     )
         ERC721M(
             collectionName,
@@ -26,7 +27,8 @@ contract ERC721MIncreasableSupply is ERC721M {
             maxMintableSupply,
             globalWalletLimit,
             cosigner,
-            timestampExpirySeconds
+            timestampExpirySeconds,
+            mintCurrency
         )
     {
         _canIncreaseMaxMintableSupply = true;

--- a/contracts/ERC721MOperatorFilterer.sol
+++ b/contracts/ERC721MOperatorFilterer.sol
@@ -13,7 +13,8 @@ contract ERC721MOperatorFilterer is ERC721M, DefaultOperatorFilterer {
         uint256 maxMintableSupply,
         uint256 globalWalletLimit,
         address cosigner,
-        uint64 timestampExpirySeconds
+        uint64 timestampExpirySeconds,
+        address mintCurrency
     )
         ERC721M(
             collectionName,
@@ -22,7 +23,8 @@ contract ERC721MOperatorFilterer is ERC721M, DefaultOperatorFilterer {
             maxMintableSupply,
             globalWalletLimit,
             cosigner,
-            timestampExpirySeconds
+            timestampExpirySeconds,
+            mintCurrency
         )
     {}
 

--- a/contracts/ERC721MOperatorFiltererAutoApprover.sol
+++ b/contracts/ERC721MOperatorFiltererAutoApprover.sol
@@ -17,6 +17,7 @@ contract ERC721MOperatorFiltererAutoApprover is ERC721MOperatorFilterer {
         uint256 globalWalletLimit,
         address cosigner,
         uint64 timestampExpirySeconds,
+        address mintCurrency,
         address autoApproveAddress
     )
         ERC721MOperatorFilterer(
@@ -26,7 +27,8 @@ contract ERC721MOperatorFiltererAutoApprover is ERC721MOperatorFilterer {
             maxMintableSupply,
             globalWalletLimit,
             cosigner,
-            timestampExpirySeconds
+            timestampExpirySeconds,
+            mintCurrency
         )
     {
         _autoApproveAddress = autoApproveAddress;

--- a/contracts/IERC721M.sol
+++ b/contracts/IERC721M.sol
@@ -56,7 +56,7 @@ interface IERC721M is IERC721AQueryable {
     event SetMintCurrency(address mintCurrency);
     event PermanentBaseURI(string baseURI);
     event Withdraw(uint256 value);
-    event WithdrawERC20(address mintCurrencyWithdrawn, uint256 value);
+    event WithdrawERC20(address mintCurrency, uint256 value);
 
     function getCosigner() external view returns (address);
 
@@ -84,6 +84,8 @@ interface IERC721M is IERC721AQueryable {
             uint32,
             uint256
         );
+
+    function getMintCurrency() external view returns (address);
 
     function getActiveStageFromTimestamp(uint64 timestamp)
         external

--- a/contracts/IERC721M.sol
+++ b/contracts/IERC721M.sol
@@ -53,8 +53,10 @@ interface IERC721M is IERC721AQueryable {
     event SetActiveStage(uint256 activeStage);
     event SetBaseURI(string baseURI);
     event SetTimestampExpirySeconds(uint64 expiry);
+    event SetMintCurrency(address mintCurrency);
     event PermanentBaseURI(string baseURI);
     event Withdraw(uint256 value);
+    event WithdrawERC20(address mintCurrencyWithdrawn, uint256 value);
 
     function getCosigner() external view returns (address);
 

--- a/contracts/IERC721M.sol
+++ b/contracts/IERC721M.sol
@@ -25,6 +25,7 @@ interface IERC721M is IERC721AQueryable {
     error WalletGlobalLimitExceeded();
     error WalletStageLimitExceeded();
     error WithdrawFailed();
+    error WrongMintCurrency();
 
     struct MintStageInfo {
         uint80 price;

--- a/contracts/mocks/MockERC20.sol
+++ b/contracts/mocks/MockERC20.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockERC20 is ERC20 {
+    constructor(uint256 initialSupply) ERC20("Mock", "MOCK") {
+    }
+
+    function mint(address to, uint256 amount) public {
+        _mint(to, amount);
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -108,6 +108,11 @@ task('deploy', 'Deploy ERC721M')
     'cosigner address (0x00...000 if not using cosign)',
     '0x0000000000000000000000000000000000000000',
   )
+  .addOptionalParam(
+    'mintcurrency',
+    'ERC-20 contract address (if minting with ERC-20)',
+    '0x0000000000000000000000000000000000000000',
+  )
   .addOptionalParam('autoapproveaddress', 'auto approve address')
   .addFlag(
     'increasesupply',
@@ -170,10 +175,7 @@ task('deployBA', 'Deploy BucketAuction')
   )
   .addParam('auctionstarttime', 'The start time of the bucket auction')
   .addParam('auctionendtime', 'The end time of the bucket auction')
-  .addFlag(
-    'useoperatorfilterer',
-    'whether or not to use operator filterer',
-  )
+  .addFlag('useoperatorfilterer', 'whether or not to use operator filterer')
   .setAction(deployBA);
 
 task('setTimestampExpirySeconds', 'Set the timestamp expiry seconds')

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -20,6 +20,7 @@ export interface IDeployParams {
   useoperatorfilterer?: boolean;
   openedition?: boolean;
   autoapproveaddress?: string;
+  mintcurrency?: string;
 }
 
 export const deploy = async (
@@ -67,6 +68,7 @@ export const deploy = async (
     hre.ethers.BigNumber.from(args.globalwalletlimit),
     args.cosigner ?? hre.ethers.constants.AddressZero,
     args.timestampexpiryseconds ?? 300,
+    args.mintcurrency ?? hre.ethers.constants.AddressZero,
     args.autoapproveaddress ?? {},
   ] as const;
 
@@ -82,7 +84,7 @@ export const deploy = async (
     ),
   );
 
-  if (!await confirm({ message: 'Continue to deploy?' })) return;
+  if (!(await confirm({ message: 'Continue to deploy?' }))) return;
 
   const erc721M = await ERC721M.deploy(...params);
 

--- a/test/ERC721MAutoApprover.test.ts
+++ b/test/ERC721MAutoApprover.test.ts
@@ -17,6 +17,7 @@ describe('ERC721MAutoApprover', () => {
       0,
       ethers.constants.AddressZero,
       300,
+      ethers.constants.AddressZero,
       test_approve_address,
     );
     const [owner] = await ethers.getSigners();

--- a/test/ERC721MIncreasableSupply.test.ts
+++ b/test/ERC721MIncreasableSupply.test.ts
@@ -15,6 +15,7 @@ describe('ERC721MIncreasableSupply', () => {
       0,
       ethers.constants.AddressZero,
       300,
+      ethers.constants.AddressZero,
     );
     const [owner] = await ethers.getSigners();
     contract = contract.connect(owner);

--- a/test/ERC721MOperatorFiltererAutoApprover.test.ts
+++ b/test/ERC721MOperatorFiltererAutoApprover.test.ts
@@ -19,6 +19,7 @@ describe('ERC721MOperatorFiltererAutoApprover', () => {
       0,
       ethers.constants.AddressZero,
       300,
+      ethers.constants.AddressZero,
       test_approve_address,
     );
     const [owner] = await ethers.getSigners();

--- a/test/erc721m.test.ts
+++ b/test/erc721m.test.ts
@@ -57,6 +57,7 @@ describe('ERC721M', function () {
       0,
       ethers.constants.AddressZero,
       60,
+      ethers.constants.AddressZero,
     );
     await erc721M.deployed();
 
@@ -1292,6 +1293,7 @@ describe('ERC721M', function () {
         0,
         ethers.constants.AddressZero,
         60,
+        ethers.constants.AddressZero,
       );
       await erc721M.deployed();
 
@@ -1366,6 +1368,7 @@ describe('ERC721M', function () {
         0,
         owner.address,
         300,
+        ethers.constants.AddressZero,
       );
       await erc721M.deployed();
 
@@ -1727,6 +1730,7 @@ describe('ERC721M', function () {
           1001,
           ethers.constants.AddressZero,
           60,
+          ethers.constants.AddressZero,
         ),
       ).to.be.revertedWith('GlobalWalletLimitOverflow');
     });
@@ -1829,6 +1833,7 @@ describe('ERC721M', function () {
         0,
         ethers.constants.AddressZero,
         60,
+        ethers.constants.AddressZero,
       );
       await erc721M.deployed();
       const ownerConn = erc721M.connect(owner);
@@ -1858,6 +1863,7 @@ describe('ERC721M', function () {
         0,
         cosigner.address,
         60,
+        ethers.constants.AddressZero,
       );
       await erc721M.deployed();
 

--- a/test/mintCurrency.test.ts
+++ b/test/mintCurrency.test.ts
@@ -1,0 +1,196 @@
+import { ERC721M } from '../typechain-types';
+import { Contract, Signer } from 'ethers';
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+
+describe('Mint Currency', () => {
+  let erc721M: ERC721M,
+    contract: ERC721M,
+    erc20: Contract,
+    owner: Signer,
+    minter: Signer;
+  const mintPrice = 50,
+    mintQty = 3,
+    mintCost = mintPrice * mintQty;
+
+  describe('deployed with ERC-20 token as mint currency', function () {
+    beforeEach(async function () {
+      // Deploy the ERC20 token contract that will be used for minting
+      const Token = await ethers.getContractFactory('MockERC20');
+      erc20 = await Token.deploy(10000);
+      await erc20.deployed();
+
+      // Deploy the ERC721M contract
+      const ERC721M = await ethers.getContractFactory('ERC721M');
+      erc721M = await ERC721M.deploy(
+        'Test',
+        'TEST',
+        '',
+        1000,
+        0,
+        ethers.constants.AddressZero,
+        60,
+        erc20.address,
+      );
+      await erc721M.deployed();
+
+      [owner, minter] = await ethers.getSigners();
+
+      contract = erc721M.connect(owner);
+
+      const block = await ethers.provider.getBlock(
+        await ethers.provider.getBlockNumber(),
+      );
+      // +10 is a number bigger than the count of transactions up to mint
+      const stageStart = block.timestamp + 10;
+      // Set stages
+      await contract.setStages([
+        {
+          price: mintPrice,
+          walletLimit: 0,
+          merkleRoot: ethers.utils.hexZeroPad('0x0', 32),
+          maxStageSupply: 5,
+          startTimeUnixSeconds: stageStart,
+          endTimeUnixSeconds: stageStart + 10000,
+        },
+      ]);
+      await contract.setMaxMintableSupply(999);
+      await contract.setMintable(true);
+
+      // Setup the test context: Update block.timestamp to comply to the stage being active
+      await ethers.provider.send('evm_mine', [stageStart - 1]);
+    });
+
+    it('should read the correct erc20 token address', async function () {
+      expect(await contract.getMintCurrency()).to.equal(erc20.address);
+    });
+
+    describe('mint', function () {
+      it('should revert mint if not enough token allowance', async function () {
+        // Give minter some mock tokens
+        const minterBalance = 1000;
+
+        await erc20.mint(await minter.getAddress(), minterBalance);
+
+        // mint should revert
+        await expect(
+          erc721M
+            .connect(minter)
+            .mint(mintQty, [ethers.utils.hexZeroPad('0x', 32)], 0, '0x00'),
+        ).to.be.revertedWith('ERC20: insufficient allowance');
+      });
+
+      it('should revert mint if not enough token balance', async function () {
+        // Give minter some mock tokens
+        const minterBalance = 1;
+        await erc20.mint(await minter.getAddress(), minterBalance);
+
+        // approve contract for erc-20 transfer
+        await erc20.connect(minter).approve(erc721M.address, mintCost);
+
+        // mint should revert
+        await expect(
+          erc721M
+            .connect(minter)
+            .mint(mintQty, [ethers.utils.hexZeroPad('0x', 32)], 0, '0x00'),
+        ).to.be.revertedWith('ERC20: transfer amount exceeds balanc');
+      });
+
+      it('should transfer the ERC20 tokens and mint when all conditions are met', async function () {
+        // Give minter some mock tokens
+        const minterBalance = 1000;
+        await erc20.mint(await minter.getAddress(), minterBalance);
+
+        // approve contract for erc-20 transfer
+        await erc20.connect(minter).approve(erc721M.address, mintCost);
+
+        // Mint tokens
+        await erc721M
+          .connect(minter)
+          .mint(mintQty, [ethers.utils.hexZeroPad('0x', 32)], 0, '0x00');
+
+        const postMintBalance = await erc20.balanceOf(
+          await minter.getAddress(),
+        );
+        expect(postMintBalance).to.equal(minterBalance - mintCost);
+
+        const contractBalance = await erc20.balanceOf(contract.address);
+        expect(contractBalance).to.equal(mintCost);
+
+        const totalMintedByMinter = await contract.totalMintedByAddress(
+          await minter.getAddress(),
+        );
+        expect(totalMintedByMinter.toNumber()).to.equal(mintQty);
+
+        const totalSupply = await contract.totalSupply();
+        expect(totalSupply.toNumber()).to.equal(mintQty);
+      });
+    });
+
+    describe('withdrawERC20', function () {
+      it('should transfer the correct amount of ERC20 tokens to the owner', async function () {
+        // First, send some ERC20 tokens to the contract
+        const initialAmount = 10;
+        await erc20.mint(erc721M.address, initialAmount);
+
+        // Then, call the withdrawERC20 function from the owner's account
+        await erc721M.connect(owner).withdrawERC20();
+
+        // Get the owner's balance
+        const ownerBalance = await erc20.balanceOf(await owner.getAddress());
+
+        // The owner's balance should now be equal to the initial amount
+        expect(ownerBalance).to.equal(initialAmount);
+      });
+    });
+
+    it('should revert if a non-owner tries to withdraw', async function () {
+      // Try to call withdrawERC20 from another account
+      await expect(erc721M.connect(minter).withdrawERC20()).to.be.revertedWith(
+        'Ownable: caller is not the owner',
+      );
+    });
+  });
+
+  describe('deployed with zero address as mint currency', function () {
+    beforeEach(async function () {
+      // Deploy the ERC721M contract
+      const ERC721M = await ethers.getContractFactory('ERC721M');
+      erc721M = await ERC721M.deploy(
+        'Test',
+        'TEST',
+        '',
+        1000,
+        0,
+        ethers.constants.AddressZero,
+        60,
+        ethers.constants.AddressZero,
+      );
+      await erc721M.deployed();
+
+      [owner, minter] = await ethers.getSigners();
+
+      contract = erc721M.connect(owner);
+    });
+
+    describe('withdrawERC20', function () {
+      it("should not change the contract's balance", async function () {
+        // Get initial balance
+        const initialBalance = await ethers.provider.getBalance(
+          contract.address,
+        );
+
+        // Expect withdrawERC20 to revert
+        await expect(contract.withdrawERC20()).to.be.revertedWith(
+          'WrongMintCurrency',
+        );
+
+        // Get final balance
+        const finalBalance = await ethers.provider.getBalance(erc721M.address);
+
+        // The initial and final balances should be the same
+        expect(initialBalance).to.equal(finalBalance);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This adds the ability to set the ERC721M contract to accept payment in an ERC-20 token rather than the native currency. These changes are non-breaking and should allow the contract to operate as before if native currency payment is all that's needed.

- `mintCurrency` is the contract address of the ERC-20 token to accept payment in. If set to 0 address (default), the contract accepts the native currency for minting
- Using OZ's [SafeERC20](https://docs.openzeppelin.com/contracts/2.x/api/token/erc20#SafeERC20) for its `safeTransferFrom` and `safeTransfer` functions that throw on failure

------

 - Unit tests complete
 - Next step is testing this manually on testnet