### PR TITLE
Add OperatorFilterer into ERC721MOnft

### DIFF
--- a/contracts/ERC721M.sol
+++ b/contracts/ERC721M.sol
@@ -114,7 +114,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
      */
     function setCosigner(address cosigner) external onlyOwner {
         _cosigner = cosigner;
-        emit SetCosigner(_cosigner);
+        emit SetCosigner(cosigner);
     }
 
     /**
@@ -130,7 +130,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
      */
     function setCrossmintAddress(address crossmintAddress) external onlyOwner {
         _crossmintAddress = crossmintAddress;
-        emit SetCrossmintAddress(_crossmintAddress);
+        emit SetCrossmintAddress(crossmintAddress);
     }
 
     /**

--- a/contracts/ERC721M.sol
+++ b/contracts/ERC721M.sol
@@ -95,26 +95,11 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
     }
 
     /**
-     * @dev Returns whether NOT mintable.
-     */
-    modifier cannotMint() {
-        if (_mintable) revert Mintable();
-        _;
-    }
-
-    /**
      * @dev Returns whether it has enough supply for the given qty.
      */
     modifier hasSupply(uint256 qty) {
         if (totalSupply() + qty > _maxMintableSupply) revert NoSupplyLeft();
         _;
-    }
-
-    /**
-     * @dev Returns cosigner address.
-     */
-    function getCosigner() external view override returns (address) {
-        return _cosigner;
     }
 
     /**
@@ -129,14 +114,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
      */
     function setCosigner(address cosigner) external onlyOwner {
         _cosigner = cosigner;
-        emit SetCosigner(cosigner);
-    }
-
-    /**
-     * @dev Returns expiry in seconds.
-     */
-    function getTimestampExpirySeconds() public view override returns (uint64) {
-        return _timestampExpirySeconds;
+        emit SetCosigner(_cosigner);
     }
 
     /**
@@ -148,18 +126,11 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
     }
 
     /**
-     * @dev Returns crossmint address.
-     */
-    function getCrossmintAddress() external view override returns (address) {
-        return _crossmintAddress;
-    }
-
-    /**
      * @dev Sets crossmint address if using crossmint. This allows the specified address to call `crossmint`.
      */
     function setCrossmintAddress(address crossmintAddress) external onlyOwner {
         _crossmintAddress = crossmintAddress;
-        emit SetCrossmintAddress(crossmintAddress);
+        emit SetCrossmintAddress(_crossmintAddress);
     }
 
     /**
@@ -191,12 +162,11 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
             _mintStages.pop();
         }
 
-        uint64 timestampExpirySeconds = getTimestampExpirySeconds();
         for (uint256 i = 0; i < newStages.length; i++) {
             if (i >= 1) {
                 if (
                     newStages[i].startTimeUnixSeconds <
-                    newStages[i - 1].endTimeUnixSeconds + timestampExpirySeconds
+                    newStages[i - 1].endTimeUnixSeconds + _timestampExpirySeconds
                 ) {
                     revert InsufficientStageTimeGap();
                 }
@@ -230,7 +200,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
     /**
      * @dev Gets whether mintable.
      */
-    function getMintable() external view override returns (bool) {
+    function getMintable() external view returns (bool) {
         return _mintable;
     }
 
@@ -344,7 +314,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
             if (
                 startTimeUnixSeconds <
                 _mintStages[index - 1].endTimeUnixSeconds +
-                    getTimestampExpirySeconds()
+                    _timestampExpirySeconds
             ) {
                 revert InsufficientStageTimeGap();
             }
@@ -374,7 +344,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
     /**
      * @dev Returns mint currency address.
      */
-    function getMintCurrency() external view override returns (address) {
+    function getMintCurrency() external view returns (address) {
         return _mintCurrency;
     }
 
@@ -536,18 +506,6 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
     }
 
     /**
-     * @dev Returns token URI suffix.
-     */
-    function getTokenURISuffix()
-        external
-        view
-        override
-        returns (string memory)
-    {
-        return _tokenURISuffix;
-    }
-
-    /**
      * @dev Sets token URI suffix. e.g. ".json".
      */
     function setTokenURISuffix(string calldata suffix) external onlyOwner {
@@ -609,7 +567,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
         uint32 qty,
         uint64 timestamp,
         bytes memory signature
-    ) public view override {
+    ) public view {
         if (
             !SignatureChecker.isValidSignatureNow(
                 _cosigner,
@@ -625,7 +583,6 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
     function getActiveStageFromTimestamp(uint64 timestamp)
         public
         view
-        override
         returns (uint256)
     {
         for (uint256 i = 0; i < _mintStages.length; i++) {
@@ -643,7 +600,7 @@ contract ERC721M is IERC721M, ERC721AQueryable, Ownable, ReentrancyGuard {
      * @dev Validates the timestamp is not expired.
      */
     function _assertValidTimestamp(uint64 timestamp) internal view {
-        if (timestamp < block.timestamp - getTimestampExpirySeconds())
+        if (timestamp < block.timestamp - _timestampExpirySeconds)
             revert TimestampExpired();
     }
 

--- a/contracts/ERC721MOnft.sol
+++ b/contracts/ERC721MOnft.sol
@@ -11,7 +11,11 @@ import {IONFT721} from "@layerzerolabs/solidity-examples/contracts/token/onft/IO
  *
  * @dev ERC721MOnft is an ERC721M contract with LayerZero integration.
  */
-contract ERC721MOnft is ERC721MLite, ONFT721CoreLite, ERC721A__IERC721Receiver {
+contract ERC721MOnft is
+    ERC721MLite,
+    ONFT721CoreLite,
+    ERC721A__IERC721Receiver
+{
     error CallerNotOwnerOrApproved();
     error FromAddressNotOwner();
     error NotExistOrNotOwnedByContract();

--- a/contracts/IERC721M.sol
+++ b/contracts/IERC721M.sol
@@ -59,23 +59,13 @@ interface IERC721M is IERC721AQueryable {
     event Withdraw(uint256 value);
     event WithdrawERC20(address mintCurrency, uint256 value);
 
-    function getCosigner() external view returns (address);
-
-    function getCrossmintAddress() external view returns (address);
-
     function getNumberStages() external view returns (uint256);
 
     function getGlobalWalletLimit() external view returns (uint256);
 
-    function getTimestampExpirySeconds() external view returns (uint64);
-
     function getMaxMintableSupply() external view returns (uint256);
 
-    function getMintable() external view returns (bool);
-
     function totalMintedByAddress(address a) external view returns (uint256);
-
-    function getTokenURISuffix() external view returns (string memory);
 
     function getStageInfo(uint256 index)
         external
@@ -85,18 +75,4 @@ interface IERC721M is IERC721AQueryable {
             uint32,
             uint256
         );
-
-    function getMintCurrency() external view returns (address);
-
-    function getActiveStageFromTimestamp(uint64 timestamp)
-        external
-        view
-        returns (uint256);
-
-    function assertValidCosign(
-        address minter,
-        uint32 qty,
-        uint64 timestamp,
-        bytes memory signature
-    ) external view;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@magiceden-oss/erc721m",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@magiceden-oss/erc721m",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "dependencies": {
         "@inquirer/prompts": "^2.2.0",
         "@layerzerolabs/solidity-examples": "^0.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magiceden-oss/erc721m",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "erc721m contract for Solidity",
   "files": [
     "/contracts/**/*.sol",

--- a/test/ERC721MOnft.test.ts
+++ b/test/ERC721MOnft.test.ts
@@ -3,7 +3,7 @@ import { Contract, Signer } from 'ethers';
 import { ethers } from 'hardhat';
 import { expect } from 'chai';
 
-describe.only('ERC721MOnft Test', () => {
+describe('ERC721MOnft Test', () => {
   let contract: ERC721MOnft;
   let lzEndpoint: Contract;
   let owner: Signer;

--- a/test/erc721m.test.ts
+++ b/test/erc721m.test.ts
@@ -519,18 +519,6 @@ describe('ERC721M', function () {
       await expect(getStageInfo).to.be.revertedWith('InvalidStage');
     });
 
-    it('can set/get timestamp expiry', async () => {
-      expect((await contract.getTimestampExpirySeconds()).toNumber()).to.eq(60);
-
-      await expect(contract.setTimestampExpirySeconds(120))
-        .to.emit(contract, 'SetTimestampExpirySeconds')
-        .withArgs(120);
-
-      expect((await contract.getTimestampExpirySeconds()).toNumber()).to.eq(
-        120,
-      );
-    });
-
     it('can find active stage', async () => {
       await contract.setStages([
         {
@@ -1318,10 +1306,6 @@ describe('ERC721M', function () {
       await ownerConn.setMintable(true);
       await ownerConn.setCrossmintAddress(crossmintAddressStr);
 
-      expect(await ownerConn.getCrossmintAddress()).to.equal(
-        crossmintAddressStr,
-      );
-
       // Impersonate Crossmint wallet
       const crossmintSigner = await ethers.getImpersonatedSigner(
         crossmintAddressStr,
@@ -1388,10 +1372,6 @@ describe('ERC721M', function () {
       ]);
       await ownerConn.setMintable(true);
       await ownerConn.setCrossmintAddress(crossmintAddressStr);
-
-      expect(await ownerConn.getCrossmintAddress()).to.equal(
-        crossmintAddressStr,
-      );
 
       // Impersonate Crossmint wallet
       const crossmintSigner = await ethers.getImpersonatedSigner(
@@ -1788,9 +1768,6 @@ describe('ERC721M', function () {
         'ipfs://bafybeidntqfipbuvdhdjosntmpxvxyse2dkyfpa635u4g6txruvt5qf7y4/',
       );
 
-      const suffix = await contract.getTokenURISuffix();
-      expect(suffix).to.equal('.json');
-
       const block = await ethers.provider.getBlock(
         await ethers.provider.getBlockNumber(),
       );
@@ -1837,14 +1814,12 @@ describe('ERC721M', function () {
       );
       await erc721M.deployed();
       const ownerConn = erc721M.connect(owner);
-      expect(await ownerConn.getCosigner()).to.eq(ethers.constants.AddressZero);
       await expect(
         ownerConn.getCosignDigest(owner.address, 1, 0),
       ).to.be.revertedWith('CosignerNotSet');
 
       // we can set the cosigner
       await ownerConn.setCosigner(cosigner.address);
-      expect(await ownerConn.getCosigner()).to.eq(cosigner.address);
 
       // readonly contract can't set cosigner
       await expect(
@@ -1868,8 +1843,6 @@ describe('ERC721M', function () {
       await erc721M.deployed();
 
       const minterConn = erc721M.connect(minter);
-      expect(await minterConn.getCosigner()).to.eq(cosigner.address);
-
       const timestamp = Math.floor(new Date().getTime() / 1000);
       const sig = await getCosignSignature(
         erc721M,


### PR DESCRIPTION
- Remove functions not being used in `IERC721M`
- Further downsize `IERC721MLite` by removing crossminting and updating specific stages
- Add OperatorFilterer into `IERC721MLite` 
- Bump package version from `0.0.10` to `0.0.11`

<img width="1130" alt="image" src="https://github.com/magicoss/erc721m/assets/95395274/1e4f1362-929e-4add-bbbb-9d3b657a3e7e">

