### PR TITLE
ERC721MPausable

### DIFF
--- a/contracts/ERC721MPausable.sol
+++ b/contracts/ERC721MPausable.sol
@@ -1,0 +1,63 @@
+//SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.4;
+
+import "@openzeppelin/contracts/security/Pausable.sol";
+import "./ERC721M.sol";
+
+contract ERC721MPausable is ERC721M, Pausable {
+    constructor(
+        string memory collectionName,
+        string memory collectionSymbol,
+        string memory tokenURISuffix,
+        uint256 maxMintableSupply,
+        uint256 globalWalletLimit,
+        address cosigner,
+        uint64 timestampExpirySeconds,
+        address mintCurrency
+    )
+    ERC721M(
+        collectionName,
+        collectionSymbol,
+        tokenURISuffix,
+        maxMintableSupply,
+        globalWalletLimit,
+        cosigner,
+        timestampExpirySeconds,
+        mintCurrency
+    )
+    {}
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) public payable virtual override(ERC721A, IERC721A) whenNotPaused {
+        super.transferFrom(from, to, tokenId);
+    }
+
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) public payable virtual override(ERC721A, IERC721A) whenNotPaused {
+        super.safeTransferFrom(from, to, tokenId);
+    }
+
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory data
+    ) public payable virtual override(ERC721A, IERC721A) whenNotPaused {
+        super.safeTransferFrom(from, to, tokenId, data);
+    }
+}

--- a/contracts/ERC721MPausableOperatorFilterer.sol
+++ b/contracts/ERC721MPausableOperatorFilterer.sol
@@ -1,0 +1,55 @@
+//SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.4;
+
+import "./ERC721MPausable.sol";
+import "./OperatorFilter/DefaultOperatorFilterer.sol";
+
+contract ERC721MPausableOperatorFilterer is ERC721MPausable, DefaultOperatorFilterer {
+    constructor(
+        string memory collectionName,
+        string memory collectionSymbol,
+        string memory tokenURISuffix,
+        uint256 maxMintableSupply,
+        uint256 globalWalletLimit,
+        address cosigner,
+        uint64 timestampExpirySeconds,
+        address mintCurrency
+    )
+    ERC721MPausable(
+            collectionName,
+            collectionSymbol,
+            tokenURISuffix,
+            maxMintableSupply,
+            globalWalletLimit,
+            cosigner,
+            timestampExpirySeconds,
+            mintCurrency
+        )
+    {}
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) public payable override(ERC721MPausable) onlyAllowedOperator(from) {
+        super.transferFrom(from, to, tokenId);
+    }
+
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) public payable override(ERC721MPausable) onlyAllowedOperator(from) {
+        super.safeTransferFrom(from, to, tokenId);
+    }
+
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory data
+    ) public payable override(ERC721MPausable) onlyAllowedOperator(from) {
+        super.safeTransferFrom(from, to, tokenId, data);
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -128,6 +128,7 @@ task('deploy', 'Deploy ERC721M')
     'increasesupply',
     'whether or not to enable increasing supply behavior',
   )
+  .addFlag('pausable', 'whether to allow transfers to be paused')
   .addFlag('useoperatorfilterer', 'whether or not to use operator filterer')
   .addFlag(
     'openedition',

--- a/scripts/common/constants.ts
+++ b/scripts/common/constants.ts
@@ -4,50 +4,56 @@ export const ContractDetails = {
   ERC721M: { name: 'ERC721M' }, // The contract of direct sales
   ERC721MIncreasableSupply: { name: 'ERC721MIncreasableSupply' }, // ERC721M with increasable supply
   ERC721MOperatorFilterer: { name: 'ERC721MOperatorFilterer' }, // ERC721M with operator filterer
-  ERC721MIncreasableOperatorFilterer: { name: 'ERC721MIncreasableOperatorFilterer' }, // ERC721M with increasable supply and operator filterer
+  ERC721MIncreasableOperatorFilterer: {
+    name: 'ERC721MIncreasableOperatorFilterer',
+  }, // ERC721M with increasable supply and operator filterer
   ERC721MAutoApprover: { name: 'ERC721MAutoApprover' }, // ERC721M with auto approver
-  ERC721MOperatorFiltererAutoApprover: { name: 'ERC721MOperatorFiltererAutoApprover' }, // ERC721M with operator filterer and auto approver
-  ERC721MOnft: { name: 'ERC721MOnft' }, // ERC721M with LayerZero integration 
-  ONFT721Lite: { name: 'ONFT721Lite' }, // ERC721 non-minting with LayerZero integration 
+  ERC721MOperatorFiltererAutoApprover: {
+    name: 'ERC721MOperatorFiltererAutoApprover',
+  }, // ERC721M with operator filterer and auto approver
+  ERC721MPausable: { name: 'ERC721MPausable' }, // ERC721M with Pausable
+  ERC721MPausableOperatorFilterer: { name: 'ERC721MPausableOperatorFilterer' }, // ERC721M with Pausable and operator filterer
+  ERC721MOnft: { name: 'ERC721MOnft' }, // ERC721M with LayerZero integration
+  ONFT721Lite: { name: 'ONFT721Lite' }, // ERC721 non-minting with LayerZero integration
   BucketAuction: { name: 'BucketAuction' }, // The contract of bucket auctions
   BucketAuctionOperatorFilterer: { name: 'BucketAuctionOperatorFilterer' }, // Bucket auction with operator filterer
 } as const;
 
 export const LayerZeroEndpoints: Record<string, string> = {
-  'ethereum': '0x66A71Dcef29A0fFBDBE3c6a460a3B5BC225Cd675',
-  'bsc': '0x3c2269811836af69497E5F486A85D7316753cf62',
-  'avalanche': '0x3c2269811836af69497E5F486A85D7316753cf62',
-  'polygon': '0x3c2269811836af69497E5F486A85D7316753cf62',
-  'arbitrum': '0x3c2269811836af69497E5F486A85D7316753cf62',
-  'optimism': '0x3c2269811836af69497E5F486A85D7316753cf62',
-  'fantom': '0xb6319cC6c8c27A8F5dAF0dD3DF91EA35C4720dd7',
-  'goerli': '0xbfD2135BFfbb0B5378b56643c2Df8a87552Bfa23',
+  ethereum: '0x66A71Dcef29A0fFBDBE3c6a460a3B5BC225Cd675',
+  bsc: '0x3c2269811836af69497E5F486A85D7316753cf62',
+  avalanche: '0x3c2269811836af69497E5F486A85D7316753cf62',
+  polygon: '0x3c2269811836af69497E5F486A85D7316753cf62',
+  arbitrum: '0x3c2269811836af69497E5F486A85D7316753cf62',
+  optimism: '0x3c2269811836af69497E5F486A85D7316753cf62',
+  fantom: '0xb6319cC6c8c27A8F5dAF0dD3DF91EA35C4720dd7',
+  goerli: '0xbfD2135BFfbb0B5378b56643c2Df8a87552Bfa23',
   'bsc-testnet': '0x6Fcb97553D41516Cb228ac03FdC8B9a0a9df04A1',
-  'fuji': '0x93f54D755A063cE7bB9e6Ac47Eccc8e33411d706',
-  'mumbai': '0xf69186dfBa60DdB133E91E9A4B5673624293d8F8',
+  fuji: '0x93f54D755A063cE7bB9e6Ac47Eccc8e33411d706',
+  mumbai: '0xf69186dfBa60DdB133E91E9A4B5673624293d8F8',
   'arbitrum-goerli': '0x6aB5Ae6822647046626e83ee6dB8187151E1d5ab',
   'optimism-goerli': '0xae92d5aD7583AD66E49A0c67BAd18F6ba52dDDc1',
   'fantom-testnet': '0x7dcAD72640F835B0FA36EFD3D6d3ec902C7E5acf',
   'meter-testnet': '0x3De2f3D1Ac59F18159ebCB422322Cb209BA96aAD',
-  'zksync-testnet': '0x093D2CF57f764f09C3c2Ac58a42A2601B8C79281'
+  'zksync-testnet': '0x093D2CF57f764f09C3c2Ac58a42A2601B8C79281',
 } as const;
 
 export const ChainIds: Record<string, number> = {
-  'ethereum': 101,
-  'bsc': 102,
-  'avalanche': 106,
-  'polygon': 109,
-  'arbitrum': 110,
-  'optimism': 111,
-  'fantom': 112,
+  ethereum: 101,
+  bsc: 102,
+  avalanche: 106,
+  polygon: 109,
+  arbitrum: 110,
+  optimism: 111,
+  fantom: 112,
 
-  'goerli': 10121,
+  goerli: 10121,
   'bsc-testnet': 10102,
-  'fuji': 10106,
-  'mumbai': 10109,
+  fuji: 10106,
+  mumbai: 10109,
   'arbitrum-goerli': 10143,
   'optimism-goerli': 10132,
   'fantom-testnet': 10112,
   'meter-testnet': 10156,
-  'zksync-testnet': 10165
-}
+  'zksync-testnet': 10165,
+};

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -20,6 +20,7 @@ export interface IDeployParams {
   useoperatorfilterer?: boolean;
   openedition?: boolean;
   autoapproveaddress?: string;
+  pausable?: boolean;
   mintcurrency?: string;
 }
 
@@ -29,21 +30,24 @@ export const deploy = async (
 ) => {
   // Compile again in case we have a coverage build (binary too large to deploy)
   await hre.run('compile');
-  let contractName: string;
-
-  if (args.increasesupply) {
-    contractName = ContractDetails.ERC721MIncreasableSupply.name;
-    if (args.useoperatorfilterer) {
+  let contractName: string = ContractDetails.ERC721M.name;
+  if (args.useoperatorfilterer) {
+    if (args.increasesupply) {
       contractName = ContractDetails.ERC721MIncreasableOperatorFilterer.name;
+    } else if (args.autoapproveaddress) {
+      contractName = ContractDetails.ERC721MOperatorFiltererAutoApprover.name;
+    } else if (args.pausable) {
+      contractName = ContractDetails.ERC721MPausableOperatorFilterer.name;
+    } else {
+      contractName = ContractDetails.ERC721MOperatorFilterer.name;
     }
   } else {
-    contractName = ContractDetails.ERC721M.name;
-    if (args.useoperatorfilterer && args.autoapproveaddress) {
-      contractName = ContractDetails.ERC721MOperatorFiltererAutoApprover.name;
-    } else if (args.useoperatorfilterer) {
-      contractName = ContractDetails.ERC721MOperatorFilterer.name;
+    if (args.increasesupply) {
+      contractName = ContractDetails.ERC721MIncreasableSupply.name;
     } else if (args.autoapproveaddress) {
       contractName = ContractDetails.ERC721MAutoApprover.name;
+    } else if (args.pausable) {
+      contractName = ContractDetails.ERC721MPausable.name;
     }
   }
 

--- a/test/ERC721MPausable.test.ts
+++ b/test/ERC721MPausable.test.ts
@@ -1,0 +1,111 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { Contract } from 'ethers';
+
+describe('ERC721MPausable', function () {
+  let erc721MPausable: Contract;
+  let owner: any;
+  let receiver: any;
+
+  beforeEach(async function () {
+    const ERC721MPausableFactory = await ethers.getContractFactory(
+      'ERC721MPausable',
+    );
+    [owner, receiver] = await ethers.getSigners();
+
+    erc721MPausable = await ERC721MPausableFactory.deploy(
+      'test',
+      'TEST',
+      '.json',
+      1000,
+      0,
+      ethers.constants.AddressZero,
+      300,
+      ethers.constants.AddressZero,
+    );
+    erc721MPausable = erc721MPausable.connect(owner);
+    await erc721MPausable.deployed();
+
+    const block = await ethers.provider.getBlock(
+      await ethers.provider.getBlockNumber(),
+    );
+    // +10 is a number bigger than the count of transactions up to mint
+    const stageStart = block.timestamp + 10;
+    // Set stages
+    await erc721MPausable.setStages([
+      {
+        price: ethers.utils.parseEther('0.5'),
+        walletLimit: 0,
+        merkleRoot: ethers.utils.hexZeroPad('0x0', 32),
+        maxStageSupply: 5,
+        startTimeUnixSeconds: stageStart,
+        endTimeUnixSeconds: stageStart + 10000,
+      },
+    ]);
+    await erc721MPausable.setMintable(true);
+    // Setup the test context: Update block.timestamp to comply to the stage being active
+    await ethers.provider.send('evm_mine', [stageStart - 1]);
+  });
+
+  describe('Test transfers when paused/unpaused', function () {
+    beforeEach(async function () {
+      const qty = 2;
+      const proof = [ethers.utils.hexZeroPad('0x', 32)]; // Placeholder
+      const timestamp = 0;
+      const signature = '0x00'; // Placeholder
+
+      await erc721MPausable.mint(qty, proof, timestamp, signature, {
+        value: ethers.utils.parseEther('50'),
+      });
+    });
+
+    it('should revert transfers when paused', async function () {
+      await erc721MPausable.pause();
+      await expect(
+        erc721MPausable.transferFrom(owner.address, receiver.address, 0),
+      ).to.be.revertedWith('Pausable: paused');
+    });
+
+    it('should allow transfers when not paused and approved', async function () {
+      await erc721MPausable.transferFrom(owner.address, receiver.address, 0);
+      expect(await erc721MPausable.ownerOf(0)).to.equal(receiver.address);
+    });
+
+    it('should revert safe transfers when paused', async function () {
+      await erc721MPausable.pause();
+
+      await expect(
+        erc721MPausable['safeTransferFrom(address,address,uint256)'](
+          owner.address,
+          receiver.address,
+          0,
+        ),
+      ).to.be.revertedWith('Pausable: paused');
+      await expect(
+        erc721MPausable['safeTransferFrom(address,address,uint256,bytes)'](
+          owner.address,
+          receiver.address,
+          0,
+          [],
+        ),
+      ).to.be.revertedWith('Pausable: paused');
+    });
+
+    it('should allow safe transfers when not paused and approved', async function () {
+      await erc721MPausable['safeTransferFrom(address,address,uint256)'](
+        owner.address,
+        receiver.address,
+        0,
+      );
+      expect(await erc721MPausable.ownerOf(0)).to.equal(receiver.address);
+
+      await erc721MPausable['safeTransferFrom(address,address,uint256,bytes)'](
+        owner.address,
+        receiver.address,
+        1,
+        [],
+      );
+      expect(await erc721MPausable.ownerOf(1)).to.equal(receiver.address);
+    });
+  });
+});

--- a/test/ERC721MPausable.test.ts
+++ b/test/ERC721MPausable.test.ts
@@ -47,6 +47,15 @@ describe('ERC721MPausable', function () {
     await ethers.provider.send('evm_mine', [stageStart - 1]);
   });
 
+  it('should revert if non-owner tries to pause/unpause', async function () {
+    await expect(erc721MPausable.connect(receiver).pause()).to.be.revertedWith(
+      'Ownable: caller is not the owner',
+    );
+    await expect(
+      erc721MPausable.connect(receiver).unpause(),
+    ).to.be.revertedWith('Ownable: caller is not the owner');
+  });
+
   describe('Test transfers when paused/unpaused', function () {
     beforeEach(async function () {
       const qty = 2;
@@ -106,6 +115,35 @@ describe('ERC721MPausable', function () {
         [],
       );
       expect(await erc721MPausable.ownerOf(1)).to.equal(receiver.address);
+    });
+  });
+
+  describe('Test other actions when paused/unpaused', function () {
+    it('should allow minting when paused', async function () {
+      const qty = 1;
+      const proof = [ethers.utils.hexZeroPad('0x', 32)]; // Placeholder
+      const timestamp = 0;
+      const signature = '0x00'; // Placeholder
+      await erc721MPausable.pause();
+      await erc721MPausable.mint(qty, proof, timestamp, signature, {
+        value: ethers.utils.parseEther('50'),
+      });
+
+      expect(await erc721MPausable.ownerOf(0)).to.equal(owner.address);
+    });
+
+    it('should allow minting when unpaused', async function () {
+      const qty = 1;
+      const proof = [ethers.utils.hexZeroPad('0x', 32)]; // Placeholder
+      const timestamp = 0;
+      const signature = '0x00'; // Placeholder
+      await erc721MPausable.pause();
+      await erc721MPausable.unpause();
+      await erc721MPausable.mint(qty, proof, timestamp, signature, {
+        value: ethers.utils.parseEther('50'),
+      });
+
+      expect(await erc721MPausable.ownerOf(0)).to.equal(owner.address);
     });
   });
 });

--- a/test/ERC721MPausableOperatorFilterer.test.ts
+++ b/test/ERC721MPausableOperatorFilterer.test.ts
@@ -1,0 +1,122 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { Contract } from 'ethers';
+
+describe('ERC721MPausableOperatorFilterer', function () {
+  let erc721MPausableOperatorFilterer: Contract;
+  let owner: any;
+  let receiver: any;
+
+  beforeEach(async function () {
+    const ERC721MPausableOperatorFiltererFactory =
+      await ethers.getContractFactory('ERC721MPausableOperatorFilterer');
+    [owner, receiver] = await ethers.getSigners();
+
+    erc721MPausableOperatorFilterer =
+      await ERC721MPausableOperatorFiltererFactory.deploy(
+        'test',
+        'TEST',
+        '.json',
+        1000,
+        0,
+        ethers.constants.AddressZero,
+        300,
+        ethers.constants.AddressZero,
+      );
+    erc721MPausableOperatorFilterer =
+      erc721MPausableOperatorFilterer.connect(owner);
+    await erc721MPausableOperatorFilterer.deployed();
+
+    const block = await ethers.provider.getBlock(
+      await ethers.provider.getBlockNumber(),
+    );
+    // +10 is a number bigger than the count of transactions up to mint
+    const stageStart = block.timestamp + 10;
+    // Set stages
+    await erc721MPausableOperatorFilterer.setStages([
+      {
+        price: ethers.utils.parseEther('0.5'),
+        walletLimit: 0,
+        merkleRoot: ethers.utils.hexZeroPad('0x0', 32),
+        maxStageSupply: 5,
+        startTimeUnixSeconds: stageStart,
+        endTimeUnixSeconds: stageStart + 10000,
+      },
+    ]);
+    await erc721MPausableOperatorFilterer.setMintable(true);
+    // Setup the test context: Update block.timestamp to comply to the stage being active
+    await ethers.provider.send('evm_mine', [stageStart - 1]);
+  });
+
+  describe('Test transfers when paused/unpaused', function () {
+    beforeEach(async function () {
+      const qty = 2;
+      const proof = [ethers.utils.hexZeroPad('0x', 32)]; // Placeholder
+      const timestamp = 0;
+      const signature = '0x00'; // Placeholder
+
+      await erc721MPausableOperatorFilterer.mint(
+        qty,
+        proof,
+        timestamp,
+        signature,
+        {
+          value: ethers.utils.parseEther('50'),
+        },
+      );
+    });
+
+    it('should revert transfers when paused', async function () {
+      await erc721MPausableOperatorFilterer.pause();
+      await expect(
+        erc721MPausableOperatorFilterer.transferFrom(
+          owner.address,
+          receiver.address,
+          0,
+        ),
+      ).to.be.revertedWith('Pausable: paused');
+    });
+
+    it('should allow transfers when not paused and approved', async function () {
+      await erc721MPausableOperatorFilterer.transferFrom(
+        owner.address,
+        receiver.address,
+        0,
+      );
+      expect(await erc721MPausableOperatorFilterer.ownerOf(0)).to.equal(
+        receiver.address,
+      );
+    });
+
+    it('should revert safe transfers when paused', async function () {
+      await erc721MPausableOperatorFilterer.pause();
+
+      await expect(
+        erc721MPausableOperatorFilterer[
+          'safeTransferFrom(address,address,uint256)'
+        ](owner.address, receiver.address, 0),
+      ).to.be.revertedWith('Pausable: paused');
+      await expect(
+        erc721MPausableOperatorFilterer[
+          'safeTransferFrom(address,address,uint256,bytes)'
+        ](owner.address, receiver.address, 0, []),
+      ).to.be.revertedWith('Pausable: paused');
+    });
+
+    it('should allow safe transfers when not paused and approved', async function () {
+      await erc721MPausableOperatorFilterer[
+        'safeTransferFrom(address,address,uint256)'
+      ](owner.address, receiver.address, 0);
+      expect(await erc721MPausableOperatorFilterer.ownerOf(0)).to.equal(
+        receiver.address,
+      );
+
+      await erc721MPausableOperatorFilterer[
+        'safeTransferFrom(address,address,uint256,bytes)'
+      ](owner.address, receiver.address, 1, []);
+      expect(await erc721MPausableOperatorFilterer.ownerOf(1)).to.equal(
+        receiver.address,
+      );
+    });
+  });
+});

--- a/test/ERC721MPausableOperatorFilterer.test.ts
+++ b/test/ERC721MPausableOperatorFilterer.test.ts
@@ -48,6 +48,15 @@ describe('ERC721MPausableOperatorFilterer', function () {
     await ethers.provider.send('evm_mine', [stageStart - 1]);
   });
 
+  it('should revert if non-owner tries to pause/unpause', async function () {
+    await expect(
+      erc721MPausableOperatorFilterer.connect(receiver).pause(),
+    ).to.be.revertedWith('Ownable: caller is not the owner');
+    await expect(
+      erc721MPausableOperatorFilterer.connect(receiver).unpause(),
+    ).to.be.revertedWith('Ownable: caller is not the owner');
+  });
+
   describe('Test transfers when paused/unpaused', function () {
     beforeEach(async function () {
       const qty = 2;
@@ -116,6 +125,51 @@ describe('ERC721MPausableOperatorFilterer', function () {
       ](owner.address, receiver.address, 1, []);
       expect(await erc721MPausableOperatorFilterer.ownerOf(1)).to.equal(
         receiver.address,
+      );
+    });
+  });
+
+  describe('Test other actions when paused/unpaused', function () {
+    it('should allow minting when paused', async function () {
+      const qty = 1;
+      const proof = [ethers.utils.hexZeroPad('0x', 32)]; // Placeholder
+      const timestamp = 0;
+      const signature = '0x00'; // Placeholder
+      await erc721MPausableOperatorFilterer.pause();
+      await erc721MPausableOperatorFilterer.mint(
+        qty,
+        proof,
+        timestamp,
+        signature,
+        {
+          value: ethers.utils.parseEther('50'),
+        },
+      );
+
+      expect(await erc721MPausableOperatorFilterer.ownerOf(0)).to.equal(
+        owner.address,
+      );
+    });
+
+    it('should allow minting when unpaused', async function () {
+      const qty = 1;
+      const proof = [ethers.utils.hexZeroPad('0x', 32)]; // Placeholder
+      const timestamp = 0;
+      const signature = '0x00'; // Placeholder
+      await erc721MPausableOperatorFilterer.pause();
+      await erc721MPausableOperatorFilterer.unpause();
+      await erc721MPausableOperatorFilterer.mint(
+        qty,
+        proof,
+        timestamp,
+        signature,
+        {
+          value: ethers.utils.parseEther('50'),
+        },
+      );
+
+      expect(await erc721MPausableOperatorFilterer.ownerOf(0)).to.equal(
+        owner.address,
       );
     });
   });


### PR DESCRIPTION
- This extends ERC721M to be pausable, allowing the contract owner to pause/unpause trading/transfers when they want
- Also adds a version with the Operator Filterer
- Add tests and deploy scripts for both
- Refactor deploy logic a bit to be more readable across the various contracts

Additionally deployed the [contract](https://polygonscan.com/address/0x660f4b1bc98a119124742af6150d723efcd153d0) and manually tested pause/unpause with transferFrom and safeTransferFrom to make sure behavior was as expected (i.e. transfers would fail simulations if the contract was paused)
- Confirmed only contract owner can pause/unpause

NOTE: pause does not affect minting - even if the contract is paused, minting can still proceed