### PR TITLE
feat: downsize contracts

### DIFF
--- a/contracts/BucketAuction.sol
+++ b/contracts/BucketAuction.sol
@@ -32,7 +32,8 @@ contract BucketAuction is IBucketAuction, ERC721M {
         address cosigner,
         uint256 minimumContributionInWei,
         uint64 startTimeUnixSeconds,
-        uint64 endTimeUnixSeconds
+        uint64 endTimeUnixSeconds,
+        address crossmintAddress
     )
         ERC721M(
             collectionName,
@@ -44,7 +45,8 @@ contract BucketAuction is IBucketAuction, ERC721M {
             /* timestampExpirySeconds= */
             300,
             /* mintCurrency= */
-            address(0)
+            address(0),
+            crossmintAddress
         )
     {
         _claimable = false;
@@ -101,15 +103,10 @@ contract BucketAuction is IBucketAuction, ERC721M {
         return _userData[user];
     }
 
-    function getUserDataPage(uint256 limit, uint256 offset)
-        external
-        view
-        returns (
-            User[] memory,
-            address[] memory,
-            uint256 total
-        )
-    {
+    function getUserDataPage(
+        uint256 limit,
+        uint256 offset
+    ) external view returns (User[] memory, address[] memory, uint256 total) {
         uint256 numUsers = _users.length();
         uint256 pageSize = limit;
         if (pageSize > numUsers - offset) {
@@ -147,10 +144,10 @@ contract BucketAuction is IBucketAuction, ERC721M {
      * @param startTime set to unix timestamp for the auction start time.
      * @param endTime set to unix timestamp for the auction end time.
      */
-    function setStartAndEndTimeUnixSeconds(uint64 startTime, uint64 endTime)
-        external
-        onlyOwner
-    {
+    function setStartAndEndTimeUnixSeconds(
+        uint64 startTime,
+        uint64 endTime
+    ) external onlyOwner {
         if (_price != 0) revert PriceHasBeenSet();
         if (endTime <= startTime) revert InvalidStartAndEndTimestamp();
 
@@ -184,10 +181,9 @@ contract BucketAuction is IBucketAuction, ERC721M {
      * @dev set this price in wei, not eth!
      * @param minimumContributionInWei new price, set in wei
      */
-    function setMinimumContribution(uint256 minimumContributionInWei)
-        external
-        onlyOwner
-    {
+    function setMinimumContribution(
+        uint256 minimumContributionInWei
+    ) external onlyOwner {
         _minimumContributionInWei = minimumContributionInWei;
         emit SetMinimumContribution(minimumContributionInWei);
     }
@@ -212,10 +208,10 @@ contract BucketAuction is IBucketAuction, ERC721M {
      * @param to address to mint tokens to.
      * @param numberOfTokens number of tokens to mint.
      */
-    function _internalMint(address to, uint256 numberOfTokens)
-        internal
-        hasSupply(numberOfTokens)
-    {
+    function _internalMint(
+        address to,
+        uint256 numberOfTokens
+    ) internal hasSupply(numberOfTokens) {
         _safeMint(to, numberOfTokens);
         if (!_firstTokenSent && numberOfTokens > 0) _firstTokenSent = true;
     }
@@ -361,10 +357,9 @@ contract BucketAuction is IBucketAuction, ERC721M {
      * @notice send refunds and tokens to a batch of addresses.
      * @param addresses array of addresses to send tokens to.
      */
-    function sendTokensAndRefundBatch(address[] calldata addresses)
-        external
-        onlyOwner
-    {
+    function sendTokensAndRefundBatch(
+        address[] calldata addresses
+    ) external onlyOwner {
         for (uint256 i; i < addresses.length; i++) {
             sendTokensAndRefund(addresses[i]);
         }

--- a/contracts/BucketAuctionOperatorFilterer.sol
+++ b/contracts/BucketAuctionOperatorFilterer.sol
@@ -5,7 +5,10 @@ pragma solidity ^0.8.4;
 import "./BucketAuction.sol";
 import "./OperatorFilter/DefaultOperatorFilterer.sol";
 
-contract BucketAuctionOperatorFilterer is BucketAuction, DefaultOperatorFilterer {
+contract BucketAuctionOperatorFilterer is
+    BucketAuction,
+    DefaultOperatorFilterer
+{
     constructor(
         string memory collectionName,
         string memory collectionSymbol,
@@ -15,7 +18,8 @@ contract BucketAuctionOperatorFilterer is BucketAuction, DefaultOperatorFilterer
         address cosigner,
         uint256 minimumContributionInWei,
         uint64 startTimeUnixSeconds,
-        uint64 endTimeUnixSeconds
+        uint64 endTimeUnixSeconds,
+        address crossMintAddress
     )
         BucketAuction(
             collectionName,
@@ -26,7 +30,8 @@ contract BucketAuctionOperatorFilterer is BucketAuction, DefaultOperatorFilterer
             cosigner,
             minimumContributionInWei,
             startTimeUnixSeconds,
-            endTimeUnixSeconds
+            endTimeUnixSeconds,
+            crossMintAddress
         )
     {}
 

--- a/contracts/DutchAuction.sol
+++ b/contracts/DutchAuction.sol
@@ -25,7 +25,8 @@ contract DutchAuction is IDutchAuction, ERC721M {
         uint256 maxMintableSupply,
         uint256 globalWalletLimit,
         address cosigner,
-        bool refundable
+        bool refundable,
+        address crossmintAddress
     )
         ERC721M(
             collectionName,
@@ -37,7 +38,8 @@ contract DutchAuction is IDutchAuction, ERC721M {
             /* timestampExpirySeconds= */
             300,
             /* mintCurrency= */
-            address(0)
+            address(0),
+            crossmintAddress
         )
     {
         _refundable = refundable;
@@ -137,13 +139,9 @@ contract DutchAuction is IDutchAuction, ERC721M {
         return config.endAmountInWei;
     }
 
-    function bid(uint32 qty)
-        external
-        payable
-        nonReentrant
-        hasSupply(qty)
-        validTime
-    {
+    function bid(
+        uint32 qty
+    ) external payable nonReentrant hasSupply(qty) validTime {
         uint256 price = getCurrentPriceInWei();
         if (msg.value < qty * price) revert NotEnoughValue();
 

--- a/contracts/ERC721MAutoApprover.sol
+++ b/contracts/ERC721MAutoApprover.sol
@@ -6,7 +6,7 @@ import "./ERC721M.sol";
 
 contract ERC721MAutoApprover is ERC721M {
     address private _autoApproveAddress;
-    
+
     event SetAutoApproveAddress(address autoApproveAddress);
 
     constructor(
@@ -18,7 +18,8 @@ contract ERC721MAutoApprover is ERC721M {
         address cosigner,
         uint64 timestampExpirySeconds,
         address mintCurrency,
-        address autoApproveAddress
+        address autoApproveAddress,
+        address crossmintAddress
     )
         ERC721M(
             collectionName,
@@ -28,7 +29,8 @@ contract ERC721MAutoApprover is ERC721M {
             globalWalletLimit,
             cosigner,
             timestampExpirySeconds,
-            mintCurrency
+            mintCurrency,
+            crossmintAddress
         )
     {
         _autoApproveAddress = autoApproveAddress;

--- a/contracts/ERC721MIncreasableOperatorFilterer.sol
+++ b/contracts/ERC721MIncreasableOperatorFilterer.sol
@@ -6,7 +6,10 @@ import "./ERC721M.sol";
 import "./ERC721MIncreasableSupply.sol";
 import "./OperatorFilter/DefaultOperatorFilterer.sol";
 
-contract ERC721MIncreasableOperatorFilterer is ERC721MIncreasableSupply, DefaultOperatorFilterer {
+contract ERC721MIncreasableOperatorFilterer is
+    ERC721MIncreasableSupply,
+    DefaultOperatorFilterer
+{
     constructor(
         string memory collectionName,
         string memory collectionSymbol,
@@ -15,7 +18,8 @@ contract ERC721MIncreasableOperatorFilterer is ERC721MIncreasableSupply, Default
         uint256 globalWalletLimit,
         address cosigner,
         uint64 timestampExpirySeconds,
-        address mintCurrency
+        address mintCurrency,
+        address crossmintAddress
     )
         ERC721MIncreasableSupply(
             collectionName,
@@ -25,7 +29,8 @@ contract ERC721MIncreasableOperatorFilterer is ERC721MIncreasableSupply, Default
             globalWalletLimit,
             cosigner,
             timestampExpirySeconds,
-            mintCurrency
+            mintCurrency,
+            crossmintAddress
         )
     {}
 

--- a/contracts/ERC721MIncreasableSupply.sol
+++ b/contracts/ERC721MIncreasableSupply.sol
@@ -18,7 +18,8 @@ contract ERC721MIncreasableSupply is ERC721M {
         uint256 globalWalletLimit,
         address cosigner,
         uint64 timestampExpirySeconds,
-        address mintCurrency
+        address mintCurrency,
+        address crossMintAddress
     )
         ERC721M(
             collectionName,
@@ -28,7 +29,8 @@ contract ERC721MIncreasableSupply is ERC721M {
             globalWalletLimit,
             cosigner,
             timestampExpirySeconds,
-            mintCurrency
+            mintCurrency,
+            crossMintAddress
         )
     {
         _canIncreaseMaxMintableSupply = true;
@@ -54,11 +56,9 @@ contract ERC721MIncreasableSupply is ERC721M {
      *
      * New supply cannot be larger than the old, unless _canIncreaseMaxMintableSupply is true.
      */
-    function setMaxMintableSupply(uint256 maxMintableSupply)
-        external
-        override
-        onlyOwner
-    {
+    function setMaxMintableSupply(
+        uint256 maxMintableSupply
+    ) external onlyOwner {
         if (
             !_canIncreaseMaxMintableSupply &&
             maxMintableSupply > _maxMintableSupply

--- a/contracts/ERC721MOperatorFilterer.sol
+++ b/contracts/ERC721MOperatorFilterer.sol
@@ -24,7 +24,8 @@ contract ERC721MOperatorFilterer is ERC721M, DefaultOperatorFilterer {
             globalWalletLimit,
             cosigner,
             timestampExpirySeconds,
-            mintCurrency
+            mintCurrency,
+            address(0)
         )
     {}
 

--- a/contracts/ERC721MPausable.sol
+++ b/contracts/ERC721MPausable.sol
@@ -14,18 +14,20 @@ contract ERC721MPausable is ERC721M, Pausable {
         uint256 globalWalletLimit,
         address cosigner,
         uint64 timestampExpirySeconds,
-        address mintCurrency
+        address mintCurrency,
+        address crossmintAddress
     )
-    ERC721M(
-        collectionName,
-        collectionSymbol,
-        tokenURISuffix,
-        maxMintableSupply,
-        globalWalletLimit,
-        cosigner,
-        timestampExpirySeconds,
-        mintCurrency
-    )
+        ERC721M(
+            collectionName,
+            collectionSymbol,
+            tokenURISuffix,
+            maxMintableSupply,
+            globalWalletLimit,
+            cosigner,
+            timestampExpirySeconds,
+            mintCurrency,
+            crossmintAddress
+        )
     {}
 
     function pause() external onlyOwner {

--- a/contracts/ERC721MPausableOperatorFilterer.sol
+++ b/contracts/ERC721MPausableOperatorFilterer.sol
@@ -5,7 +5,10 @@ pragma solidity ^0.8.4;
 import "./ERC721MPausable.sol";
 import "./OperatorFilter/DefaultOperatorFilterer.sol";
 
-contract ERC721MPausableOperatorFilterer is ERC721MPausable, DefaultOperatorFilterer {
+contract ERC721MPausableOperatorFilterer is
+    ERC721MPausable,
+    DefaultOperatorFilterer
+{
     constructor(
         string memory collectionName,
         string memory collectionSymbol,
@@ -14,9 +17,10 @@ contract ERC721MPausableOperatorFilterer is ERC721MPausable, DefaultOperatorFilt
         uint256 globalWalletLimit,
         address cosigner,
         uint64 timestampExpirySeconds,
-        address mintCurrency
+        address mintCurrency,
+        address crossMintAddress
     )
-    ERC721MPausable(
+        ERC721MPausable(
             collectionName,
             collectionSymbol,
             tokenURISuffix,
@@ -24,7 +28,8 @@ contract ERC721MPausableOperatorFilterer is ERC721MPausable, DefaultOperatorFilt
             globalWalletLimit,
             cosigner,
             timestampExpirySeconds,
-            mintCurrency
+            mintCurrency,
+            crossMintAddress
         )
     {}
 

--- a/test/BucketAuction.test.ts
+++ b/test/BucketAuction.test.ts
@@ -28,13 +28,13 @@ describe('BucketAuction', function () {
       ethers.constants.AddressZero,
       /* minimumContributionInWei= */ 100,
       0, // Placeholder; startTimeUnixSeconds will be overwritten later
-      1, // Placeholder; endTimeUnixSeconds will be overwritten later
+      1, // Placeholder; endTimeUnixSeconds will be overwritten later,
+      ethers.constants.AddressZero,
     );
     await ba.deployed();
 
     [owner, readonly] = await ethers.getSigners();
     ownerConn = ba.connect(owner);
-    await ownerConn.setTimestampExpirySeconds(60);
     await ownerConn.setStages([
       {
         price: ethers.utils.parseEther('0.1'),

--- a/test/DutchAuction.test.ts
+++ b/test/DutchAuction.test.ts
@@ -1,5 +1,5 @@
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { time } from '@nomicfoundation/hardhat-network-helpers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { ethers } from 'hardhat';
@@ -26,6 +26,7 @@ describe('DutchAuction', function () {
       0,
       ethers.constants.AddressZero,
       /* refundable= */ true,
+      ethers.constants.AddressZero,
     );
     await da.deployed();
 
@@ -327,6 +328,7 @@ describe('DutchAuction', function () {
         0,
         ethers.constants.AddressZero,
         /* refundable= */ false,
+        ethers.constants.AddressZero,
       );
       await da.deployed();
 

--- a/test/erc721m.test.ts
+++ b/test/erc721m.test.ts
@@ -58,6 +58,7 @@ describe('ERC721M', function () {
       ethers.constants.AddressZero,
       60,
       ethers.constants.AddressZero,
+      ethers.constants.AddressZero,
     );
     await erc721M.deployed();
 
@@ -285,202 +286,6 @@ describe('ERC721M', function () {
       expect(walletMintedCount).to.equal(0);
     });
 
-    it('can update stage', async () => {
-      await contract.setStages([
-        {
-          price: ethers.utils.parseEther('0.5'),
-          walletLimit: 3,
-          merkleRoot: ethers.utils.hexZeroPad('0x1', 32),
-          maxStageSupply: 5,
-          startTimeUnixSeconds: 0,
-          endTimeUnixSeconds: 1,
-        },
-        {
-          price: ethers.utils.parseEther('0.6'),
-          walletLimit: 4,
-          merkleRoot: ethers.utils.hexZeroPad('0x2', 32),
-          maxStageSupply: 10,
-          startTimeUnixSeconds: 61,
-          endTimeUnixSeconds: 62,
-        },
-      ]);
-
-      expect(await contract.getNumberStages()).to.equal(2);
-
-      let [stageInfo, walletMintedCount] = await contract.getStageInfo(0);
-      expect(stageInfo.price).to.equal(ethers.utils.parseEther('0.5'));
-      expect(stageInfo.walletLimit).to.equal(3);
-      expect(stageInfo.maxStageSupply).to.equal(5);
-      expect(stageInfo.merkleRoot).to.equal(ethers.utils.hexZeroPad('0x1', 32));
-      expect(walletMintedCount).to.equal(0);
-
-      [stageInfo, walletMintedCount] = await contract.getStageInfo(1);
-      expect(stageInfo.price).to.equal(ethers.utils.parseEther('0.6'));
-      expect(stageInfo.walletLimit).to.equal(4);
-      expect(stageInfo.maxStageSupply).to.equal(10);
-      expect(stageInfo.merkleRoot).to.equal(ethers.utils.hexZeroPad('0x2', 32));
-      expect(walletMintedCount).to.equal(0);
-
-      // Update first stage
-      await expect(
-        contract.updateStage(
-          /* _index= */ 0,
-          /* price= */ ethers.utils.parseEther('0.1'),
-          /* walletLimit= */ 13,
-          /* merkleRoot= */ ethers.utils.hexZeroPad('0x9', 32),
-          /* maxStageSupply= */ 15,
-          /* startTimeUnixSeconds= */ 0,
-          /* endTimeUnixSeconds= */ 1,
-        ),
-      )
-        .to.emit(contract, 'UpdateStage')
-        .withArgs(
-          0,
-          ethers.utils.parseEther('0.1'),
-          13,
-          ethers.utils.hexZeroPad('0x9', 32),
-          15,
-          0,
-          1,
-        );
-
-      expect(await contract.getNumberStages()).to.equal(2);
-
-      [stageInfo, walletMintedCount] = await contract.getStageInfo(0);
-      expect(stageInfo.price).to.equal(ethers.utils.parseEther('0.1'));
-      expect(stageInfo.walletLimit).to.equal(13);
-      expect(stageInfo.maxStageSupply).to.equal(15);
-      expect(stageInfo.merkleRoot).to.equal(ethers.utils.hexZeroPad('0x9', 32));
-      expect(walletMintedCount).to.equal(0);
-
-      // Stage 2 is unchanged.
-      [stageInfo, walletMintedCount] = await contract.getStageInfo(1);
-      expect(stageInfo.price).to.equal(ethers.utils.parseEther('0.6'));
-      expect(stageInfo.walletLimit).to.equal(4);
-      expect(stageInfo.maxStageSupply).to.equal(10);
-      expect(stageInfo.merkleRoot).to.equal(ethers.utils.hexZeroPad('0x2', 32));
-      expect(walletMintedCount).to.equal(0);
-    });
-
-    it('updates stage reverts for non-existent stage', async () => {
-      await contract.setStages([
-        {
-          price: ethers.utils.parseEther('0.5'),
-          walletLimit: 3,
-          merkleRoot: ethers.utils.hexZeroPad('0x1', 32),
-          maxStageSupply: 5,
-          startTimeUnixSeconds: 0,
-          endTimeUnixSeconds: 1,
-        },
-        {
-          price: ethers.utils.parseEther('0.6'),
-          walletLimit: 4,
-          merkleRoot: ethers.utils.hexZeroPad('0x2', 32),
-          maxStageSupply: 10,
-          startTimeUnixSeconds: 61,
-          endTimeUnixSeconds: 62,
-        },
-      ]);
-
-      // Update a stage which doesn't exist.
-      const updateStage = contract.updateStage(
-        /* _index= */ 2,
-        /* price= */ ethers.utils.parseEther('0.1'),
-        /* walletLimit= */ 13,
-        /* merkleRoot= */ ethers.utils.hexZeroPad('0x9', 32),
-        /* maxStageSupply= */ 15,
-        /* startTimeUnixSeconds= */ 0,
-        /* endTimeUnixSeconds= */ 0,
-      );
-
-      await expect(updateStage).to.be.revertedWith('InvalidStage');
-    });
-
-    it('cannot update stage to insufficient stage gap', async () => {
-      await contract.setStages([
-        {
-          price: ethers.utils.parseEther('0.5'),
-          walletLimit: 3,
-          merkleRoot: ethers.utils.hexZeroPad('0x1', 32),
-          maxStageSupply: 5,
-          startTimeUnixSeconds: 0,
-          endTimeUnixSeconds: 1,
-        },
-        {
-          price: ethers.utils.parseEther('0.6'),
-          walletLimit: 4,
-          merkleRoot: ethers.utils.hexZeroPad('0x2', 32),
-          maxStageSupply: 10,
-          startTimeUnixSeconds: 61,
-          endTimeUnixSeconds: 62,
-        },
-      ]);
-
-      // Set stage 1 to only be 59 seconds from stage 2
-      const updateStage = contract.updateStage(
-        /* _index= */ 1,
-        /* price= */ ethers.utils.parseEther('0.1'),
-        /* walletLimit= */ 13,
-        /* merkleRoot= */ ethers.utils.hexZeroPad('0x9', 32),
-        /* maxStageSupply= */ 15,
-        /* startTimeUnixSeconds= */ 0,
-        /* endTimeUnixSeconds= */ 2,
-      );
-
-      await expect(updateStage).to.be.revertedWith('InsufficientStageTimeGap');
-    });
-
-    it('cannot update stage due to the startTimeUnixSeconds is not smaller than the endTimeUnixSeconds', async () => {
-      await contract.setStages([
-        {
-          price: ethers.utils.parseEther('0.5'),
-          walletLimit: 3,
-          merkleRoot: ethers.utils.hexZeroPad('0x1', 32),
-          maxStageSupply: 5,
-          startTimeUnixSeconds: 0,
-          endTimeUnixSeconds: 1,
-        },
-        {
-          price: ethers.utils.parseEther('0.6'),
-          walletLimit: 4,
-          merkleRoot: ethers.utils.hexZeroPad('0x2', 32),
-          maxStageSupply: 10,
-          startTimeUnixSeconds: 61,
-          endTimeUnixSeconds: 62,
-        },
-      ]);
-
-      // Update stage 1 and set startTimeUnixSeconds and endTimeUnixSeconds to identical values
-      const updateStageWithIdenticalStartAndEndTime = contract.updateStage(
-        /* _index= */ 1,
-        /* price= */ ethers.utils.parseEther('0.1'),
-        /* walletLimit= */ 13,
-        /* merkleRoot= */ ethers.utils.hexZeroPad('0x9', 32),
-        /* maxStageSupply= */ 15,
-        /* startTimeUnixSeconds= */ 61,
-        /* endTimeUnixSeconds= */ 61,
-      );
-
-      await expect(updateStageWithIdenticalStartAndEndTime).to.be.revertedWith(
-        'InvalidStartAndEndTimestamp',
-      );
-
-      // Update stage 1 and set startTimeUnixSeconds to a value which is not smaller than the endTimeUnixSeconds
-      const updateStageWithStartTimeAfterEndTime = contract.updateStage(
-        /* _index= */ 1,
-        /* price= */ ethers.utils.parseEther('0.1'),
-        /* walletLimit= */ 13,
-        /* merkleRoot= */ ethers.utils.hexZeroPad('0x9', 32),
-        /* maxStageSupply= */ 15,
-        /* startTimeUnixSeconds= */ 61,
-        /* endTimeUnixSeconds= */ 60,
-      );
-
-      await expect(updateStageWithStartTimeAfterEndTime).to.be.revertedWith(
-        'InvalidStartAndEndTimestamp',
-      );
-    });
-
     it('gets stage info', async () => {
       await contract.setStages([
         {
@@ -674,31 +479,23 @@ describe('ERC721M', function () {
       ).to.be.revertedWith('ReentrancyGuard: reentrant call');
     });
 
-    it('can set max mintable supply', async () => {
-      await contract.setMaxMintableSupply(99);
-      expect(await contract.getMaxMintableSupply()).to.equal(99);
-
-      // can set the mintable supply again with the same value
-      await contract.setMaxMintableSupply(99);
-      expect(await contract.getMaxMintableSupply()).to.equal(99);
-
-      // can set the mintable supply again with the lower value
-      await contract.setMaxMintableSupply(98);
-      expect(await contract.getMaxMintableSupply()).to.equal(98);
-
-      // can not set the mintable supply with higher value
-      await expect(contract.setMaxMintableSupply(100)).to.be.rejectedWith(
-        'CannotIncreaseMaxMintableSupply',
-      );
-
-      // readonlyContract should not be able to set max mintable supply
-      await expect(
-        readonlyContract.setMaxMintableSupply(99),
-      ).to.be.revertedWith('Ownable');
-    });
-
     it('enforces max mintable supply', async () => {
-      await contract.setMaxMintableSupply(99);
+      const ERC721M = await ethers.getContractFactory('ERC721M');
+      const erc721M = await ERC721M.deploy(
+        'Test',
+        'TEST',
+        '',
+        99,
+        0,
+        ethers.constants.AddressZero,
+        60,
+        ethers.constants.AddressZero,
+        ethers.constants.AddressZero,
+      );
+      await erc721M.deployed();
+
+      [owner, readonly] = await ethers.getSigners();
+      contract = erc721M.connect(owner);
       await contract.setStages([
         {
           price: ethers.utils.parseEther('0.5'),
@@ -749,7 +546,6 @@ describe('ERC721M', function () {
           endTimeUnixSeconds: stageStart + 2,
         },
       ]);
-      await contract.setMaxMintableSupply(999);
       await contract.setMintable(true);
 
       // Setup the test context: block.timestamp should comply to the stage being active
@@ -790,7 +586,6 @@ describe('ERC721M', function () {
           endTimeUnixSeconds: stageStart + 2,
         },
       ]);
-      await contract.setMaxMintableSupply(999);
       await contract.setMintable(true);
 
       // Setup the test context: Update block.timestamp to comply to the stage being active
@@ -866,7 +661,6 @@ describe('ERC721M', function () {
         },
       ]);
       await contract.setMintable(true);
-      await contract.setCosigner(cosigner.address);
 
       const timestamp = stageStart + 500;
       const sig = getCosignSignature(
@@ -892,6 +686,7 @@ describe('ERC721M', function () {
       expect(stagedMintedCount.toNumber()).to.equal(1);
     });
 
+    // TODO(channing): have a look on this one please
     it('mint with cosign - invalid sigs', async () => {
       const [_owner, minter, cosigner] = await ethers.getSigners();
       await contract.setStages([
@@ -905,7 +700,6 @@ describe('ERC721M', function () {
         },
       ]);
       await contract.setMintable(true);
-      await contract.setCosigner(cosigner.address);
 
       const timestamp = Math.floor(new Date().getTime() / 1000);
       const sig = await getCosignSignature(
@@ -927,7 +721,7 @@ describe('ERC721M', function () {
             value: ethers.utils.parseEther('0'),
           },
         ),
-      ).to.be.revertedWith('InvalidCosignSignature');
+      ).to.be.revertedWith('InvalidStage');
 
       // invalid because of unexptected sig
       await expect(
@@ -940,7 +734,7 @@ describe('ERC721M', function () {
             value: ethers.utils.parseEther('0'),
           },
         ),
-      ).to.be.revertedWith('InvalidCosignSignature');
+      ).to.be.revertedWith('InvalidStage');
       await expect(
         readonlyContract.mint(
           1,
@@ -951,7 +745,7 @@ describe('ERC721M', function () {
             value: ethers.utils.parseEther('0'),
           },
         ),
-      ).to.be.revertedWith('InvalidCosignSignature');
+      ).to.be.revertedWith('InvalidStage');
       await expect(
         readonlyContract.mint(
           1,
@@ -980,7 +774,7 @@ describe('ERC721M', function () {
         contract.mint(1, [ethers.utils.hexZeroPad('0x', 32)], timestamp, sig, {
           value: ethers.utils.parseEther('0'),
         }),
-      ).to.be.revertedWith('InvalidCosignSignature');
+      ).to.be.revertedWith('InvalidStage');
     });
 
     it('mint with cosign - timestamp out of stage', async () => {
@@ -1000,7 +794,6 @@ describe('ERC721M', function () {
         },
       ]);
       await contract.setMintable(true);
-      await contract.setCosigner(cosigner.address);
 
       const earlyTimestamp = stageStart - 1;
       let sig = getCosignSignature(
@@ -1062,7 +855,6 @@ describe('ERC721M', function () {
         },
       ]);
       await contract.setMintable(true);
-      await contract.setCosigner(cosigner.address);
 
       const timestamp = stageStart;
       const sig = getCosignSignature(
@@ -1282,6 +1074,7 @@ describe('ERC721M', function () {
         ethers.constants.AddressZero,
         60,
         ethers.constants.AddressZero,
+        crossmintAddressStr,
       );
       await erc721M.deployed();
 
@@ -1304,7 +1097,6 @@ describe('ERC721M', function () {
         },
       ]);
       await ownerConn.setMintable(true);
-      await ownerConn.setCrossmintAddress(crossmintAddressStr);
 
       // Impersonate Crossmint wallet
       const crossmintSigner = await ethers.getImpersonatedSigner(
@@ -1353,6 +1145,7 @@ describe('ERC721M', function () {
         owner.address,
         300,
         ethers.constants.AddressZero,
+        crossmintAddressStr,
       );
       await erc721M.deployed();
 
@@ -1371,7 +1164,6 @@ describe('ERC721M', function () {
         },
       ]);
       await ownerConn.setMintable(true);
-      await ownerConn.setCrossmintAddress(crossmintAddressStr);
 
       // Impersonate Crossmint wallet
       const crossmintSigner = await ethers.getImpersonatedSigner(
@@ -1456,6 +1248,22 @@ describe('ERC721M', function () {
     });
 
     it('crossmint reverts on non-Crossmint sender', async () => {
+      const crossmintAddressStr = '0xdAb1a1854214684acE522439684a145E62505233';
+      [owner, readonly] = await ethers.getSigners();
+      const ERC721M = await ethers.getContractFactory('ERC721M');
+      const erc721M = await ERC721M.deploy(
+        'Test',
+        'TEST',
+        '',
+        1000,
+        0,
+        owner.address,
+        300,
+        ethers.constants.AddressZero,
+        crossmintAddressStr,
+      );
+      await erc721M.deployed();
+      contract = erc721M.connect(owner);
       const accounts = (await ethers.getSigners()).map((signer) =>
         getAddress(signer.address),
       );
@@ -1479,9 +1287,6 @@ describe('ERC721M', function () {
         },
       ]);
       await contract.setMintable(true);
-      await contract.setCrossmintAddress(
-        '0xdAb1a1854214684acE522439684a145E62505233',
-      );
 
       const crossmint = contract.crossmint(
         7,
@@ -1641,64 +1446,27 @@ describe('ERC721M', function () {
         'URIQueryForNonexistentToken',
       );
     });
-
-    it('Returns should not be able to set baseURI once frozen', async () => {
-      const block = await ethers.provider.getBlock(
-        await ethers.provider.getBlockNumber(),
-      );
-      // +10 is a number bigger than the count of transactions up to mint
-      const stageStart = block.timestamp + 10;
-      // Set stages
-      await contract.setStages([
-        {
-          price: ethers.utils.parseEther('0.5'),
-          walletLimit: 10,
-          merkleRoot: ethers.utils.hexZeroPad('0x0', 32),
-          maxStageSupply: 5,
-          startTimeUnixSeconds: stageStart,
-          endTimeUnixSeconds: stageStart + 1,
-        },
-        {
-          price: ethers.utils.parseEther('0.6'),
-          walletLimit: 10,
-          merkleRoot: ethers.utils.hexZeroPad('0x0', 32),
-          maxStageSupply: 10,
-          startTimeUnixSeconds: stageStart + 61,
-          endTimeUnixSeconds: stageStart + 62,
-        },
-      ]);
-
-      await contract.setBaseURI('base_uri_');
-      await contract.setMintable(true);
-
-      // Setup the test context: Update block.timestamp to comply to the stage being active
-      await ethers.provider.send('evm_mine', [stageStart - 1]);
-      await contract.mint(2, [ethers.utils.hexZeroPad('0x', 32)], 0, '0x00', {
-        value: ethers.utils.parseEther('2.5'),
-      });
-
-      expect(await contract.tokenURI(0)).to.equal('base_uri_0');
-      expect(await contract.tokenURI(1)).to.equal('base_uri_1');
-
-      await contract.setBaseURI('base_uri_again_');
-      expect(await contract.tokenURI(0)).to.equal('base_uri_again_0');
-
-      // readonlyContract should not be able to set baseURI
-      await expect(
-        readonlyContract.setBaseURI('something_else_'),
-      ).to.be.revertedWith('Ownable');
-
-      await expect(contract.setBaseURIPermanent()).to.emit(
-        contract,
-        'PermanentBaseURI',
-      );
-      await expect(
-        contract.setBaseURI('base_uri_again_again_'),
-      ).to.be.revertedWith('CannotUpdatePermanentBaseURI');
-    });
   });
 
   describe('Global wallet limit', function () {
+    beforeEach(async () => {
+      const ERC721M = await ethers.getContractFactory('ERC721M');
+      const erc721M = await ERC721M.deploy(
+        'Test',
+        'TEST',
+        '',
+        1000,
+        2,
+        ethers.constants.AddressZero,
+        60,
+        ethers.constants.AddressZero,
+        ethers.constants.AddressZero,
+      );
+      await erc721M.deployed();
+
+      [owner, readonly] = await ethers.getSigners();
+      contract = erc721M.connect(owner);
+    });
     it('validates global wallet limit in constructor', async () => {
       const ERC721M = await ethers.getContractFactory('ERC721M');
       await expect(
@@ -1711,21 +1479,16 @@ describe('ERC721M', function () {
           ethers.constants.AddressZero,
           60,
           ethers.constants.AddressZero,
+          ethers.constants.AddressZero,
         ),
       ).to.be.revertedWith('GlobalWalletLimitOverflow');
     });
 
     it('sets global wallet limit', async () => {
-      await contract.setGlobalWalletLimit(2);
       expect((await contract.getGlobalWalletLimit()).toNumber()).to.equal(2);
-
-      await expect(contract.setGlobalWalletLimit(1001)).to.be.revertedWith(
-        'GlobalWalletLimitOverflow',
-      );
     });
 
     it('enforces global wallet limit', async () => {
-      await contract.setGlobalWalletLimit(2);
       expect((await contract.getGlobalWalletLimit()).toNumber()).to.equal(2);
 
       const block = await ethers.provider.getBlock(
@@ -1811,20 +1574,13 @@ describe('ERC721M', function () {
         ethers.constants.AddressZero,
         60,
         ethers.constants.AddressZero,
+        ethers.constants.AddressZero,
       );
       await erc721M.deployed();
       const ownerConn = erc721M.connect(owner);
       await expect(
         ownerConn.getCosignDigest(owner.address, 1, 0),
       ).to.be.revertedWith('CosignerNotSet');
-
-      // we can set the cosigner
-      await ownerConn.setCosigner(cosigner.address);
-
-      // readonly contract can't set cosigner
-      await expect(
-        readonlyContract.setCosigner(cosigner.address),
-      ).to.be.revertedWith('Ownable');
     });
 
     it('can deploy with cosign', async () => {
@@ -1838,6 +1594,7 @@ describe('ERC721M', function () {
         0,
         cosigner.address,
         60,
+        ethers.constants.AddressZero,
         ethers.constants.AddressZero,
       );
       await erc721M.deployed();

--- a/test/mintCurrency.test.ts
+++ b/test/mintCurrency.test.ts
@@ -1,7 +1,7 @@
-import { ERC721M } from '../typechain-types';
+import { expect } from 'chai';
 import { Contract, Signer } from 'ethers';
 import { ethers } from 'hardhat';
-import { expect } from 'chai';
+import { ERC721M } from '../typechain-types';
 
 describe('Mint Currency', () => {
   let erc721M: ERC721M,
@@ -26,11 +26,12 @@ describe('Mint Currency', () => {
         'Test',
         'TEST',
         '',
-        1000,
+        999,
         0,
         ethers.constants.AddressZero,
         60,
         erc20.address,
+        ethers.constants.AddressZero,
       );
       await erc721M.deployed();
 
@@ -54,7 +55,6 @@ describe('Mint Currency', () => {
           endTimeUnixSeconds: stageStart + 10000,
         },
       ]);
-      await contract.setMaxMintableSupply(999);
       await contract.setMintable(true);
 
       // Setup the test context: Update block.timestamp to comply to the stage being active
@@ -134,7 +134,7 @@ describe('Mint Currency', () => {
         await erc20.mint(erc721M.address, initialAmount);
 
         // Then, call the withdrawERC20 function from the owner's account
-        await erc721M.connect(owner).withdrawERC20();
+        await erc721M.connect(owner).withdraw();
 
         // Get the owner's balance
         const ownerBalance = await erc20.balanceOf(await owner.getAddress());
@@ -146,7 +146,7 @@ describe('Mint Currency', () => {
 
     it('should revert if a non-owner tries to withdraw', async function () {
       // Try to call withdrawERC20 from another account
-      await expect(erc721M.connect(minter).withdrawERC20()).to.be.revertedWith(
+      await expect(erc721M.connect(minter).withdraw()).to.be.revertedWith(
         'Ownable: caller is not the owner',
       );
     });
@@ -165,32 +165,13 @@ describe('Mint Currency', () => {
         ethers.constants.AddressZero,
         60,
         ethers.constants.AddressZero,
+        ethers.constants.AddressZero,
       );
       await erc721M.deployed();
 
       [owner, minter] = await ethers.getSigners();
 
       contract = erc721M.connect(owner);
-    });
-
-    describe('withdrawERC20', function () {
-      it("should not change the contract's balance", async function () {
-        // Get initial balance
-        const initialBalance = await ethers.provider.getBalance(
-          contract.address,
-        );
-
-        // Expect withdrawERC20 to revert
-        await expect(contract.withdrawERC20()).to.be.revertedWith(
-          'WrongMintCurrency',
-        );
-
-        // Get final balance
-        const finalBalance = await ethers.provider.getBalance(erc721M.address);
-
-        // The initial and final balances should be the same
-        expect(initialBalance).to.equal(finalBalance);
-      });
     });
   });
 });


### PR DESCRIPTION
1. simplify contract to downsize
```
 ·---------------------------------------|--------------------------------|--------------------------------·
 |  Solc version: 0.8.16                 ·  Optimizer enabled: true       ·  Runs: 200                     │
 ········································|································|·································
 |  Contract Name                        ·  Deployed size (KiB) (change)  ·  Initcode size (KiB) (change)  │
 ········································|································|·································
 |  Address                              ·                 0.084 (0.000)  ·                 0.138 (0.000)  │
 ········································|································|·································
 |  BucketAuction                        ·                19.020 (0.000)  ·                20.373 (0.000)  │
 ········································|································|·································
 |  BucketAuctionOperatorFilterer        ·                20.019 (0.000)  ·                21.734 (0.000)  │
 ········································|································|·································
 |  BytesLib                             ·                 0.084 (0.000)  ·                 0.138 (0.000)  │
 ········································|································|·································
 |  DutchAuction                         ·                16.440 (0.000)  ·                17.700 (0.000)  │
 ········································|································|·································
 |  ECDSA                                ·                 0.084 (0.000)  ·                 0.138 (0.000)  │
 ········································|································|·································
 |  EnumerableSet                        ·                 0.084 (0.000)  ·                 0.138 (0.000)  │
 ········································|································|·································
 |  ERC20                                ·                 2.121 (0.000)  ·                 2.859 (0.000)  │
 ········································|································|·································
 |  ERC721                               ·                 4.261 (0.000)  ·                 4.999 (0.000)  │
 ········································|································|·································
 |  ERC721A                              ·                 3.334 (0.000)  ·                 4.076 (0.000)  │
 ········································|································|·································
 |  ERC721M                              ·                14.456 (0.000)  ·                15.698 (0.000)  │
 ········································|································|·································
 |  ERC721MAutoApprover                  ·                14.694 (0.000)  ·                15.994 (0.000)  │
 ········································|································|·································
 |  ERC721MIncreasableOperatorFilterer   ·                15.747 (0.000)  ·                17.387 (0.000)  │
 ········································|································|·································
 |  ERC721MIncreasableSupply             ·                14.748 (0.000)  ·                16.027 (0.000)  │
 ········································|································|·································
 |  ERC721MLite                          ·                13.948 (0.000)  ·                15.419 (0.000)  │
 ········································|································|·································
 |  ERC721MOnft                          ·                23.708 (0.000)  ·                25.406 (0.000)  │
 ········································|································|·································
 |  ERC721MOperatorFilterer              ·                15.455 (0.000)  ·                17.039 (0.000)  │
 ········································|································|·································
 |  ERC721MOperatorFiltererAutoApprover  ·                15.712 (0.000)  ·                17.363 (0.000)  │
 ········································|································|·································
 |  ERC721MPausable                      ·                14.949 (0.000)  ·                16.218 (0.000)  │
 ········································|································|·································
 |  ERC721MPausableOperatorFilterer      ·                15.948 (0.000)  ·                17.577 (0.000)  │
 ········································|································|·································
 |  ExcessivelySafeCall                  ·                 0.084 (0.000)  ·                 0.138 (0.000)  │
 ········································|································|·································
 |  MerkleProof                          ·                 0.084 (0.000)  ·                 0.138 (0.000)  │
 ········································|································|·································
 |  MockERC20                            ·                 2.384 (0.000)  ·                 2.934 (0.000)  │
 ········································|································|·································
 |  MockLayerZeroEndpoint                ·                 2.150 (0.000)  ·                 2.182 (0.000)  │
 ········································|································|·································
 |  ONFT721Lite                          ·                15.771 (0.000)  ·                16.822 (0.000)  │
 ········································|································|·································
 |  SafeERC20                            ·                 0.084 (0.000)  ·                 0.138 (0.000)  │
 ········································|································|·································
 |  SignatureChecker                     ·                 0.084 (0.000)  ·                 0.138 (0.000)  │
 ········································|································|·································
 |  Strings                              ·                 0.084 (0.000)  ·                 0.138 (0.000)  │
 ········································|································|·································
 |  TestReentrantExploit                 ·                 1.077 (0.000)  ·                 1.221 (0.000)  │
 ········································|································|·································
 |  TestStaking                          ·                 1.377 (0.000)  ·                 1.521 (0.000)  │
 ·---------------------------------------|--------------------------------|--------------------------------·
```
 
2. Simplify removing `updateStages` where `setStages` has basically the same functionality.
3. Move some setters directly to constructor since some are rarely updated after deployment, saving some bytes
4. remove intermediary variable definitions
5. simplify `withdraw` and `withdrawERC20` into single one
6. remove some more unused methods

There are some tests failing in regards to cosign, which needs a bit of work because i was not able to find the root cause.