### PR TITLE
fix: ERC721CMRoyalties supportsInterface logic

### DIFF
--- a/contracts/ERC721CMBasicRoyalties.sol
+++ b/contracts/ERC721CMBasicRoyalties.sol
@@ -41,6 +41,8 @@ contract ERC721CMBasicRoyalties is ERC721CM, BasicRoyalties {
         override(ERC2981, ERC721ACQueryable, IERC721A)
         returns (bool)
     {
-        return super.supportsInterface(interfaceId);
+        return
+            ERC721ACQueryable.supportsInterface(interfaceId) ||
+            ERC2981.supportsInterface(interfaceId);
     }
 }

--- a/contracts/ERC721CMRoyalties.sol
+++ b/contracts/ERC721CMRoyalties.sol
@@ -41,6 +41,8 @@ contract ERC721CMRoyalties is ERC721CM, UpdatableRoyalties {
         override(ERC2981, ERC721ACQueryable, IERC721A)
         returns (bool)
     {
-        return super.supportsInterface(interfaceId);
+        return
+            ERC721ACQueryable.supportsInterface(interfaceId) ||
+            ERC2981.supportsInterface(interfaceId);
     }
 }

--- a/contracts/creator-token-standards/ERC721ACQueryable.sol
+++ b/contracts/creator-token-standards/ERC721ACQueryable.sol
@@ -22,7 +22,7 @@ abstract contract ERC721ACQueryable is ERC721AQueryable, CreatorTokenBase {
     {
         return
             interfaceId == type(ICreatorToken).interfaceId ||
-            super.supportsInterface(interfaceId);
+            ERC721A.supportsInterface(interfaceId);
     }
 
     /// @dev Ties the erc721a _beforeTokenTransfers hook to more granular transfer validation logic

--- a/test/ERC721CMBasicRoyalties.test.ts
+++ b/test/ERC721CMBasicRoyalties.test.ts
@@ -11,7 +11,9 @@ describe('ERC721CMBasicRoyalties', function () {
   let owner: SignerWithAddress;
 
   beforeEach(async () => {
-    const ERC721CMBasicRoyalties = await ethers.getContractFactory('ERC721CMBasicRoyalties');
+    const ERC721CMBasicRoyalties = await ethers.getContractFactory(
+      'ERC721CMBasicRoyalties',
+    );
     const erc721cmBasicRoyalties = await ERC721CMBasicRoyalties.deploy(
       'Test',
       'TEST',
@@ -32,15 +34,28 @@ describe('ERC721CMBasicRoyalties', function () {
 
   it('Royalty info', async () => {
     let royaltyInfo = await contract.royaltyInfo(0, 1000);
-    expect(royaltyInfo[0]).to.equal('0x0764844ac95ABCa4F6306E592c7D9C9f3615f590');
+    expect(royaltyInfo[0]).to.equal(
+      '0x0764844ac95ABCa4F6306E592c7D9C9f3615f590',
+    );
     expect(royaltyInfo[1].toNumber()).to.equal(1);
 
     royaltyInfo = await contract.royaltyInfo(1, 9999);
-    expect(royaltyInfo[0]).to.equal('0x0764844ac95ABCa4F6306E592c7D9C9f3615f590');
+    expect(royaltyInfo[0]).to.equal(
+      '0x0764844ac95ABCa4F6306E592c7D9C9f3615f590',
+    );
     expect(royaltyInfo[1].toNumber()).to.equal(9);
 
     royaltyInfo = await contract.royaltyInfo(1111, 9999999999);
-    expect(royaltyInfo[0]).to.equal('0x0764844ac95ABCa4F6306E592c7D9C9f3615f590');
+    expect(royaltyInfo[0]).to.equal(
+      '0x0764844ac95ABCa4F6306E592c7D9C9f3615f590',
+    );
     expect(royaltyInfo[1].toNumber()).to.equal(9999999);
+  });
+
+  it('Supports the right interfaces', async () => {
+    expect(await contract.supportsInterface('0x01ffc9a7')).to.be.true; // IERC165
+    expect(await contract.supportsInterface('0x80ac58cd')).to.be.true; // IERC721
+    expect(await contract.supportsInterface('0x5b5e139f')).to.be.true; // IERC721Metadata
+    expect(await contract.supportsInterface('0x2a55205a')).to.be.true; // IERC2981
   });
 });

--- a/test/ERC721CMRoyalties.test.ts
+++ b/test/ERC721CMRoyalties.test.ts
@@ -15,7 +15,9 @@ describe('ERC721CMRoyalties', function () {
   let owner: SignerWithAddress;
 
   beforeEach(async () => {
-    const ERC721CMRoyalties = await ethers.getContractFactory('ERC721CMRoyalties');
+    const ERC721CMRoyalties = await ethers.getContractFactory(
+      'ERC721CMRoyalties',
+    );
     erc721cmRoyalties = await ERC721CMRoyalties.deploy(
       'Test',
       'TEST',
@@ -47,7 +49,7 @@ describe('ERC721CMRoyalties', function () {
     expect(royaltyInfo[0]).to.equal(WALLET_1);
     expect(royaltyInfo[1].toNumber()).to.equal(9999999);
 
-    await connection.setDefaultRoyalty(WALLET_2, 0)
+    await connection.setDefaultRoyalty(WALLET_2, 0);
 
     royaltyInfo = await connection.royaltyInfo(0, 1000);
     expect(royaltyInfo[0]).to.equal(WALLET_2);
@@ -75,7 +77,7 @@ describe('ERC721CMRoyalties', function () {
     expect(royaltyInfo[0]).to.equal(WALLET_1);
     expect(royaltyInfo[1].toNumber()).to.equal(9999999);
 
-    await connection.setTokenRoyalty(1, WALLET_2, 100)
+    await connection.setTokenRoyalty(1, WALLET_2, 100);
 
     royaltyInfo = await connection.royaltyInfo(0, 1000);
     expect(royaltyInfo[0]).to.equal(WALLET_1);
@@ -95,11 +97,18 @@ describe('ERC721CMRoyalties', function () {
     const nonOwnerConnection = erc721cmRoyalties.connect(nonOwner);
 
     await expect(
-      nonOwnerConnection.setTokenRoyalty(1, WALLET_2, 100)
-      ).to.be.revertedWith('Ownable: caller is not the owner');
+      nonOwnerConnection.setTokenRoyalty(1, WALLET_2, 100),
+    ).to.be.revertedWith('Ownable: caller is not the owner');
 
     await expect(
-      nonOwnerConnection.setDefaultRoyalty(WALLET_2, 0)
-      ).to.be.revertedWith('Ownable: caller is not the owner');
+      nonOwnerConnection.setDefaultRoyalty(WALLET_2, 0),
+    ).to.be.revertedWith('Ownable: caller is not the owner');
+  });
+
+  it('Supports the right interfaces', async () => {
+    expect(await erc721cmRoyalties.supportsInterface('0x01ffc9a7')).to.be.true; // IERC165
+    expect(await erc721cmRoyalties.supportsInterface('0x80ac58cd')).to.be.true; // IERC721
+    expect(await erc721cmRoyalties.supportsInterface('0x5b5e139f')).to.be.true; // IERC721Metadata
+    expect(await erc721cmRoyalties.supportsInterface('0x2a55205a')).to.be.true; // IERC2981
   });
 });


### PR DESCRIPTION
Naively using `super.supportsInterface(interfaceId)` is incorrect when using ERC721A contracts. ERC721A does not inherit from OpenZeppelin's contracts so the 721 interfaces need to be explicitly included in `supportsInterface`.