### PR TITLE
Added gasprice + gaslimit override params

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -185,6 +185,8 @@ task('ownerMint', 'Mint token(s) as owner')
   .addParam('contract', 'contract address')
   .addParam('qty', 'quantity to mint', '1')
   .addOptionalParam('to', 'recipient address')
+  .addOptionalParam('gaspricegwei', 'Set gas price in Gwei')
+  .addOptionalParam('gaslimit', 'Set maximum gas units to spend on transaction')
   .setAction(ownerMint);
 
 task('setGlobalWalletLimit', 'Set the global wallet limit')

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -159,6 +159,8 @@ task('deploy', 'Deploy ERC721M')
   .addOptionalParam<boolean>('useerc2198', 'whether or not to use ERC2198', true, types.boolean)
   .addOptionalParam('erc2198royaltyreceiver', 'erc2198 royalty receiver address')
   .addOptionalParam('erc2198royaltyfeenumerator', 'erc2198 royalty fee numerator')
+  .addOptionalParam('gaspricegwei', 'Set gas price in Gwei')
+  .addOptionalParam('gaslimit', 'Set maximum gas units to spend on transaction')
   .setAction(deploy);
 
 task('setBaseURI', 'Set the base uri')

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -117,6 +117,7 @@ task('setStages', 'Set stages for ERC721M')
   .addParam('contract', 'contract address')
   .addParam('stages', 'stages json file')
   .addOptionalParam('gaspricegwei', 'Set gas price in Gwei')
+  .addOptionalParam('gaslimit', 'Set maximum gas units to spend on transaction', 500000, types.int)
   .setAction(setStages);
 
 task('setMintable', 'Set mintable state for ERC721M')

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -168,6 +168,7 @@ task('setBaseURI', 'Set the base uri')
   .addParam('uri', 'uri')
   .addParam('contract', 'contract address')
   .addOptionalParam('gaspricegwei', 'Set gas price in Gwei')
+  .addOptionalParam('gaslimit', 'Set maximum gas units to spend on transaction', 500000, types.int)
   .setAction(setBaseURI);
 
 task('setCrossmintAddress', 'Set crossmint address')

--- a/scripts/ownerMint.ts
+++ b/scripts/ownerMint.ts
@@ -2,11 +2,14 @@ import { confirm } from '@inquirer/prompts';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { ContractDetails } from './common/constants';
 import { estimateGas } from './utils/helper';
+import { Overrides } from 'ethers';
 
 export interface IOwnerMintParams {
   contract: string;
   to?: string;
   qty?: string;
+  gaspricegwei?: number;
+  gaslimit?: number;
 }
 
 export const ownerMint = async (
@@ -19,13 +22,20 @@ export const ownerMint = async (
   const contract = ERC721M.attach(args.contract);
   const qty = ethers.BigNumber.from(args.qty ?? 1);
   const to = args.to ?? (await contract.signer.getAddress());
+  const overrides: Overrides = {};
+  if (args.gaspricegwei) {
+    overrides.gasPrice = ethers.BigNumber.from(args.gaspricegwei * 1e9);
+  }
+  if (args.gaslimit) {
+    overrides.gasLimit = ethers.BigNumber.from(args.gaslimit);
+  }
 
   const tx = await contract.populateTransaction.ownerMint(qty, to);
-  await estimateGas(hre, tx);
+  if (!(await estimateGas(hre, tx, overrides))) return;
   console.log(`Going to mint ${qty.toNumber()} token(s) to ${to}`);
   if (!await confirm({ message: 'Continue?' })) return;
 
-  const submittedTx = await contract.ownerMint(qty, to);
+  const submittedTx = await contract.ownerMint(qty, to, overrides);
 
   console.log(`Submitted tx ${submittedTx.hash}`);
   await submittedTx.wait();

--- a/scripts/setBaseURI.ts
+++ b/scripts/setBaseURI.ts
@@ -1,10 +1,13 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { ContractDetails } from './common/constants';
+import { Overrides } from 'ethers';
+import { estimateGas } from './utils/helper';
 
 export interface ISetBaseURIParams {
   uri: string;
   contract: string;
   gaspricegwei?: number;
+  gaslimit?: number;
 }
 
 export const setBaseURI = async (
@@ -12,18 +15,22 @@ export const setBaseURI = async (
   hre: HardhatRuntimeEnvironment,
 ) => {
   const { ethers } = hre;
-  const overrides: any = {gasLimit: 500_000};
-
+  const overrides: Overrides = {};
   if (args.gaspricegwei) {
-    overrides.gasPrice = args.gaspricegwei * 1e9;
+    overrides.gasPrice = ethers.BigNumber.from(args.gaspricegwei * 1e9);
+  }
+  if (args.gaslimit) {
+    overrides.gasLimit = ethers.BigNumber.from(args.gaslimit);
   }
   const ERC721M = await ethers.getContractFactory(ContractDetails.ERC721M.name);
   const contract = ERC721M.attach(args.contract);
-  const tx = await contract.setBaseURI(args.uri, overrides);
+  const tx = await contract.populateTransaction.setBaseURI(args.uri);
+  if (!(await estimateGas(hre, tx, overrides))) return;
+  const submittedTx = await contract.setBaseURI(args.uri, overrides);
 
-  console.log(`Submitted tx ${tx.hash}`);
+  console.log(`Submitted tx ${submittedTx.hash}`);
 
-  await tx.wait();
+  await submittedTx.wait();
 
-  console.log('Set baseURI:', tx.hash);
+  console.log('Set baseURI:', submittedTx.hash);
 };


### PR DESCRIPTION
## Summary

Added gasprice + gaslimit override params to the following commands:
- deploy
- setStages
- ownerMint
- setBaseURI

Updated the `estimateGas` util with extra confirmations to safeguard against accidental overrides and wasting money on gas.
![image](https://github.com/magicoss/erc721m/assets/101311451/a77f476e-267e-49aa-bcd2-97d1f6990022)

## Testing

### Starting - Wallet Balance: 
![image](https://github.com/magicoss/erc721m/assets/101311451/32d283c5-d43e-4b73-b1a1-d0cfe292c0d1)

### Normal call (no override gaspricegwei):
Command:
`npx hardhat --network polygon deploy --name ERC721CM --symbol ERC721CMR2 --maxsupply 1000 --erc2198royaltyreceiver 0xa6da3705F53B516078AF138Bd99eF8708436981D --erc2198royaltyfeenumerator 500`
Pre-run output:
![image](https://github.com/magicoss/erc721m/assets/101311451/547b26c9-2792-49d1-a08b-562661c99645)

Tx: [0x0649699cde118acd375d00317dd03a401044e92a75cbd02e5ae0afb146242773](https://polygonscan.com/tx/0x0649699cde118acd375d00317dd03a401044e92a75cbd02e5ae0afb146242773)
Contract: 0x5f5B9c37ef920B349eCF100aBFf9AE3BEE4c6792
Actual output:
![image](https://github.com/magicoss/erc721m/assets/101311451/5445202c-217f-46ef-aa46-817a3f9f685c)

### Updated call (using override gaspricegwei):
Command:
`npx hardhat --network polygon deploy --name ERC721CM --symbol ERC721CMR2 --maxsupply 1000 --erc2198royaltyreceiver 0xa6da3705F53B516078AF138Bd99eF8708436981D --erc2198royaltyfeenumerator 500 --gaspricegwei 200 --gaslimit 5000000`
Pre-run output:
![image](https://github.com/magicoss/erc721m/assets/101311451/909b65ac-8316-482c-8645-10fec70a72f0)

Tx: [0x5dbb9f648cd3315f8effc40bfd8e8d3814bb3f632d91b5ae2af2c3a3db2ba093](https://polygonscan.com/tx/0x5dbb9f648cd3315f8effc40bfd8e8d3814bb3f632d91b5ae2af2c3a3db2ba093)
Contract: 0xF038BBF62F05DB95e2f4a353B056Bc51F78B461f
Actual output:
![image](https://github.com/magicoss/erc721m/assets/101311451/20779cd0-e2cf-49b7-91b1-f96430da4926)

