### PR TITLE
Withdraw fund to treasury wallet

### DIFF
--- a/contracts/ERC721CMBasicRoyalties.sol
+++ b/contracts/ERC721CMBasicRoyalties.sol
@@ -18,6 +18,7 @@ contract ERC721CMBasicRoyalties is ERC721CM, BasicRoyalties {
         address cosigner,
         uint64 timestampExpirySeconds,
         address mintCurrency,
+        address fundReceiver,
         address royaltyReceiver,
         uint96 royaltyFeeNumerator
     )
@@ -29,7 +30,8 @@ contract ERC721CMBasicRoyalties is ERC721CM, BasicRoyalties {
             globalWalletLimit,
             cosigner,
             timestampExpirySeconds,
-            mintCurrency
+            mintCurrency,
+            fundReceiver
         )
         BasicRoyalties(royaltyReceiver, royaltyFeeNumerator)
     {}

--- a/contracts/ERC721CMRoyalties.sol
+++ b/contracts/ERC721CMRoyalties.sol
@@ -18,6 +18,7 @@ contract ERC721CMRoyalties is ERC721CM, UpdatableRoyalties {
         address cosigner,
         uint64 timestampExpirySeconds,
         address mintCurrency,
+        address fundReceiver,
         address royaltyReceiver,
         uint96 royaltyFeeNumerator
     )
@@ -29,7 +30,8 @@ contract ERC721CMRoyalties is ERC721CM, UpdatableRoyalties {
             globalWalletLimit,
             cosigner,
             timestampExpirySeconds,
-            mintCurrency
+            mintCurrency,
+            fundReceiver
         )
         UpdatableRoyalties(royaltyReceiver, royaltyFeeNumerator)
     {}

--- a/contracts/ERC721MOperatorFilterer.sol
+++ b/contracts/ERC721MOperatorFilterer.sol
@@ -15,7 +15,8 @@ contract ERC721MOperatorFilterer is ERC721M, UpdatableOperatorFilterer {
         uint256 globalWalletLimit,
         address cosigner,
         uint64 timestampExpirySeconds,
-        address mintCurrency
+        address mintCurrency,
+        address fundReceiver
     )
         UpdatableOperatorFilterer(
             CANONICAL_OPERATOR_FILTER_REGISTRY_ADDRESS,
@@ -30,7 +31,8 @@ contract ERC721MOperatorFilterer is ERC721M, UpdatableOperatorFilterer {
             globalWalletLimit,
             cosigner,
             timestampExpirySeconds,
-            mintCurrency
+            mintCurrency,
+            fundReceiver
         )
     {}
 

--- a/contracts/auctions/BucketAuction.sol
+++ b/contracts/auctions/BucketAuction.sol
@@ -32,7 +32,8 @@ contract BucketAuction is IBucketAuction, ERC721M {
         address cosigner,
         uint256 minimumContributionInWei,
         uint64 startTimeUnixSeconds,
-        uint64 endTimeUnixSeconds
+        uint64 endTimeUnixSeconds,
+        address fundReceiver
     )
         ERC721M(
             collectionName,
@@ -44,7 +45,8 @@ contract BucketAuction is IBucketAuction, ERC721M {
             /* timestampExpirySeconds= */
             300,
             /* mintCurrency= */
-            address(0)
+            address(0),
+            fundReceiver
         )
     {
         _claimable = false;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -152,6 +152,10 @@ task('deploy', 'Deploy ERC721M')
     'ERC-20 contract address (if minting with ERC-20)',
     '0x0000000000000000000000000000000000000000',
   )
+  .addOptionalParam(
+    'fundreceiver',
+    'The treasury wallet to receive mint fund',
+  )
   .addParam<boolean>(
     'useoperatorfilterer',
     'whether or not to use operator filterer, used with legacy 721M contract',

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -21,6 +21,7 @@ interface IDeployParams {
   useoperatorfilterer?: boolean;
   openedition?: boolean;
   mintcurrency?: string;
+  fundreceiver?: string;
   useerc721c?: boolean;
   useerc2198?: boolean;
   erc2198royaltyreceiver?: string;
@@ -63,7 +64,8 @@ export const deploy = async (
     overrides.gasLimit = hre.ethers.BigNumber.from(args.gaslimit);
   }
 
-  const contractFactory = await hre.ethers.getContractFactory(contractName);
+  const [signer] = await hre.ethers.getSigners();
+  const contractFactory = await hre.ethers.getContractFactory(contractName, signer);
 
   const params = [
     args.name,
@@ -74,6 +76,7 @@ export const deploy = async (
     args.cosigner ?? hre.ethers.constants.AddressZero,
     args.timestampexpiryseconds ?? 300,
     args.mintcurrency ?? hre.ethers.constants.AddressZero,
+    args.fundreceiver ?? signer.address,
   ] as any[];
 
   if (args.useerc2198) {

--- a/test/BucketAuction.test.ts
+++ b/test/BucketAuction.test.ts
@@ -18,6 +18,8 @@ describe('BucketAuction', function () {
   let auctionEndTimestamp = 1;
 
   beforeEach(async () => {
+    [owner, readonly] = await ethers.getSigners();
+
     const BA = await ethers.getContractFactory('BucketAuction');
     ba = await BA.deploy(
       'Test',
@@ -29,10 +31,10 @@ describe('BucketAuction', function () {
       /* minimumContributionInWei= */ 100,
       0, // Placeholder; startTimeUnixSeconds will be overwritten later
       1, // Placeholder; endTimeUnixSeconds will be overwritten later
+      owner.address,
     );
     await ba.deployed();
 
-    [owner, readonly] = await ethers.getSigners();
     ownerConn = ba.connect(owner);
     await ownerConn.setTimestampExpirySeconds(60);
     await ownerConn.setStages([

--- a/test/ERC721CM.test.ts
+++ b/test/ERC721CM.test.ts
@@ -14,6 +14,7 @@ describe('ERC721CM', function () {
   let contract: ERC721CM;
   let readonlyContract: ERC721CM;
   let owner: SignerWithAddress;
+  let fundReceiver: SignerWithAddress;
   let readonly: SignerWithAddress;
   let chainId: number;
 
@@ -49,6 +50,8 @@ describe('ERC721CM', function () {
   };
 
   beforeEach(async () => {
+    [owner, readonly, fundReceiver] = await ethers.getSigners();
+
     const ERC721CM = await ethers.getContractFactory('ERC721CM');
     const erc721cm = await ERC721CM.deploy(
       'Test',
@@ -59,10 +62,10 @@ describe('ERC721CM', function () {
       ethers.constants.AddressZero,
       60,
       ethers.constants.AddressZero,
+      fundReceiver.address,
     );
     await erc721cm.deployed();
 
-    [owner, readonly] = await ethers.getSigners();
     contract = erc721cm.connect(owner);
     readonlyContract = erc721cm.connect(readonly);
     chainId = await ethers.provider.getNetwork().then((n) => n.chainId);
@@ -95,8 +98,8 @@ describe('ERC721CM', function () {
     ).to.equal(100);
 
     await expect(() => contract.withdraw()).to.changeEtherBalances(
-      [contract, owner],
-      [-100, 100],
+      [contract, owner, fundReceiver],
+      [-100, 0, 100],
     );
 
     expect(
@@ -1277,6 +1280,8 @@ describe('ERC721CM', function () {
 
     it('crossmint', async () => {
       const crossmintAddressStr = '0xdAb1a1854214684acE522439684a145E62505233';
+      [owner, readonly, fundReceiver] = await ethers.getSigners();
+
       const ERC721CM = await ethers.getContractFactory('ERC721CM');
       const erc721cm = await ERC721CM.deploy(
         'Test',
@@ -1287,10 +1292,10 @@ describe('ERC721CM', function () {
         ethers.constants.AddressZero,
         60,
         ethers.constants.AddressZero,
+        fundReceiver.address,
       );
       await erc721cm.deployed();
 
-      [owner, readonly] = await ethers.getSigners();
       const ownerConn = erc721cm.connect(owner);
       const block = await ethers.provider.getBlock(
         await ethers.provider.getBlockNumber(),
@@ -1347,7 +1352,7 @@ describe('ERC721CM', function () {
 
     it('crossmint with cosign', async () => {
       const crossmintAddressStr = '0xdAb1a1854214684acE522439684a145E62505233';
-      [owner, readonly] = await ethers.getSigners();
+      [owner, readonly, fundReceiver] = await ethers.getSigners();
       const ERC721CM = await ethers.getContractFactory('ERC721CM');
       const erc721cm = await ERC721CM.deploy(
         'Test',
@@ -1358,6 +1363,7 @@ describe('ERC721CM', function () {
         owner.address,
         300,
         ethers.constants.AddressZero,
+        fundReceiver.address,
       );
       await erc721cm.deployed();
 
@@ -1673,6 +1679,7 @@ describe('ERC721CM', function () {
           ethers.constants.AddressZero,
           60,
           ethers.constants.AddressZero,
+          fundReceiver.address,
         ),
       ).to.be.revertedWith('GlobalWalletLimitOverflow');
     });
@@ -1764,7 +1771,7 @@ describe('ERC721CM', function () {
 
   describe('Cosign', () => {
     it('can deploy with 0x0 cosign', async () => {
-      const [owner, cosigner] = await ethers.getSigners();
+      const [owner, cosigner, fundReceiver] = await ethers.getSigners();
       const ERC721CM = await ethers.getContractFactory('ERC721CM');
       const erc721cm = await ERC721CM.deploy(
         'Test',
@@ -1775,6 +1782,7 @@ describe('ERC721CM', function () {
         ethers.constants.AddressZero,
         60,
         ethers.constants.AddressZero,
+        fundReceiver.address,
       );
       await erc721cm.deployed();
       const ownerConn = erc721cm.connect(owner);
@@ -1792,7 +1800,7 @@ describe('ERC721CM', function () {
     });
 
     it('can deploy with cosign', async () => {
-      const [_, minter, cosigner] = await ethers.getSigners();
+      const [_, minter, cosigner, fundReceiver] = await ethers.getSigners();
       const ERC721CM = await ethers.getContractFactory('ERC721CM');
       const erc721cm = await ERC721CM.deploy(
         'Test',
@@ -1803,6 +1811,7 @@ describe('ERC721CM', function () {
         cosigner.address,
         60,
         ethers.constants.AddressZero,
+        fundReceiver.address,
       );
       await erc721cm.deployed();
 

--- a/test/ERC721CMBasicRoyalties.test.ts
+++ b/test/ERC721CMBasicRoyalties.test.ts
@@ -11,6 +11,8 @@ describe('ERC721CMBasicRoyalties', function () {
   let owner: SignerWithAddress;
 
   beforeEach(async () => {
+    [owner] = await ethers.getSigners();
+
     const ERC721CMBasicRoyalties = await ethers.getContractFactory(
       'ERC721CMBasicRoyalties',
     );
@@ -23,12 +25,12 @@ describe('ERC721CMBasicRoyalties', function () {
       ethers.constants.AddressZero,
       60,
       ethers.constants.AddressZero,
+      owner.address,
       '0x0764844ac95ABCa4F6306E592c7D9C9f3615f590', // erc2198royaltyreceiver
       10, // erc2198royaltyfeenumerator
     );
     await erc721cmBasicRoyalties.deployed();
 
-    [owner] = await ethers.getSigners();
     contract = erc721cmBasicRoyalties.connect(owner);
   });
 

--- a/test/ERC721CMRoyalties.test.ts
+++ b/test/ERC721CMRoyalties.test.ts
@@ -15,6 +15,8 @@ describe('ERC721CMRoyalties', function () {
   let owner: SignerWithAddress;
 
   beforeEach(async () => {
+    [owner] = await ethers.getSigners();
+
     const ERC721CMRoyalties =
       await ethers.getContractFactory('ERC721CMRoyalties');
     erc721cmRoyalties = await ERC721CMRoyalties.deploy(
@@ -26,12 +28,12 @@ describe('ERC721CMRoyalties', function () {
       ethers.constants.AddressZero,
       60,
       ethers.constants.AddressZero,
+      owner.address,
       WALLET_1, // erc2198royaltyreceiver
       10, // erc2198royaltyfeenumerator
     );
     await erc721cmRoyalties.deployed();
 
-    [owner] = await ethers.getSigners();
     connection = erc721cmRoyalties.connect(owner);
   });
 

--- a/test/ERC721M.test.ts
+++ b/test/ERC721M.test.ts
@@ -16,6 +16,7 @@ describe('ERC721M', function () {
   let contract: ERC721M;
   let readonlyContract: ERC721M;
   let owner: SignerWithAddress;
+  let fundReceiver: SignerWithAddress;
   let readonly: SignerWithAddress;
   let chainId: number;
 
@@ -51,6 +52,8 @@ describe('ERC721M', function () {
   };
 
   beforeEach(async () => {
+    [owner, readonly, fundReceiver] = await ethers.getSigners();
+
     const ERC721M = await ethers.getContractFactory('ERC721M');
     const erc721M = await ERC721M.deploy(
       'Test',
@@ -61,10 +64,10 @@ describe('ERC721M', function () {
       ethers.constants.AddressZero,
       60,
       ethers.constants.AddressZero,
+      fundReceiver.address,
     );
     await erc721M.deployed();
 
-    [owner, readonly] = await ethers.getSigners();
     contract = erc721M.connect(owner);
     readonlyContract = erc721M.connect(readonly);
     chainId = await ethers.provider.getNetwork().then((n) => n.chainId);
@@ -101,8 +104,8 @@ describe('ERC721M', function () {
     ).to.equal(100);
 
     await expect(() => contract.withdraw()).to.changeEtherBalances(
-      [contract, owner],
-      [-100, 100],
+      [contract, owner, fundReceiver],
+      [-100, 0, 100],
     );
 
     expect(
@@ -1310,6 +1313,7 @@ describe('ERC721M', function () {
         ethers.constants.AddressZero,
         60,
         ethers.constants.AddressZero,
+        fundReceiver.address,
       );
       await erc721M.deployed();
 
@@ -1370,7 +1374,7 @@ describe('ERC721M', function () {
 
     it('crossmint with cosign', async () => {
       const crossmintAddressStr = '0xdAb1a1854214684acE522439684a145E62505233';
-      [owner, readonly] = await ethers.getSigners();
+      [owner, readonly, fundReceiver] = await ethers.getSigners();
       const ERC721M = await ethers.getContractFactory('ERC721M');
       const erc721M = await ERC721M.deploy(
         'Test',
@@ -1381,6 +1385,7 @@ describe('ERC721M', function () {
         owner.address,
         300,
         ethers.constants.AddressZero,
+        fundReceiver.address,
       );
       await erc721M.deployed();
 
@@ -1692,6 +1697,7 @@ describe('ERC721M', function () {
           ethers.constants.AddressZero,
           60,
           ethers.constants.AddressZero,
+          fundReceiver.address,
         ),
       ).to.be.revertedWith('GlobalWalletLimitOverflow');
     });
@@ -1783,7 +1789,7 @@ describe('ERC721M', function () {
 
   describe('Cosign', () => {
     it('can deploy with 0x0 cosign', async () => {
-      const [owner, cosigner] = await ethers.getSigners();
+      const [owner, cosigner, fundReceiver] = await ethers.getSigners();
       const ERC721M = await ethers.getContractFactory('ERC721M');
       const erc721M = await ERC721M.deploy(
         'Test',
@@ -1794,6 +1800,7 @@ describe('ERC721M', function () {
         ethers.constants.AddressZero,
         60,
         ethers.constants.AddressZero,
+        fundReceiver.address,
       );
       await erc721M.deployed();
       const ownerConn = erc721M.connect(owner);
@@ -1811,7 +1818,7 @@ describe('ERC721M', function () {
     });
 
     it('can deploy with cosign', async () => {
-      const [_, minter, cosigner] = await ethers.getSigners();
+      const [_, minter, cosigner, fundReceiver] = await ethers.getSigners();
       const ERC721M = await ethers.getContractFactory('ERC721M');
       const erc721M = await ERC721M.deploy(
         'Test',
@@ -1822,6 +1829,7 @@ describe('ERC721M', function () {
         cosigner.address,
         60,
         ethers.constants.AddressZero,
+        fundReceiver.address,
       );
       await erc721M.deployed();
 

--- a/test/mintCurrency.test.ts
+++ b/test/mintCurrency.test.ts
@@ -4,11 +4,12 @@ import { ethers } from 'hardhat';
 import { expect } from 'chai';
 
 describe('ERC721M: Mint Currency', () => {
-  let erc721M: ERC721M,
-    contract: ERC721M,
-    erc20: Contract,
-    owner: Signer,
-    minter: Signer;
+  let erc721M: ERC721M;
+  let contract: ERC721M;
+  let erc20: Contract;
+  let owner: Signer;
+  let fundReceiver: Signer;
+  let minter: Signer;
   const mintPrice = 50;
   const mintFee = 10;
   const mintQty = 3;
@@ -16,6 +17,8 @@ describe('ERC721M: Mint Currency', () => {
 
   describe('deployed with ERC-20 token as mint currency', function () {
     beforeEach(async function () {
+      [owner, minter, fundReceiver] = await ethers.getSigners();
+
       // Deploy the ERC20 token contract that will be used for minting
       const Token = await ethers.getContractFactory('MockERC20');
       erc20 = await Token.deploy(10000);
@@ -32,10 +35,10 @@ describe('ERC721M: Mint Currency', () => {
         ethers.constants.AddressZero,
         60,
         erc20.address,
+        fundReceiver.getAddress(),
       );
       await erc721M.deployed();
 
-      [owner, minter] = await ethers.getSigners();
 
       contract = erc721M.connect(owner);
 
@@ -138,11 +141,10 @@ describe('ERC721M: Mint Currency', () => {
         // Then, call the withdrawERC20 function from the owner's account
         await erc721M.connect(owner).withdrawERC20();
 
-        // Get the owner's balance
-        const ownerBalance = await erc20.balanceOf(await owner.getAddress());
+        // Get the balance of fundReceiver
+        const fundReceiverBalance = await erc20.balanceOf(await fundReceiver.getAddress());
 
-        // The owner's balance should now be equal to the initial amount
-        expect(ownerBalance).to.equal(initialAmount);
+        expect(fundReceiverBalance).to.equal(initialAmount);
       });
     });
 
@@ -167,6 +169,7 @@ describe('ERC721M: Mint Currency', () => {
         ethers.constants.AddressZero,
         60,
         ethers.constants.AddressZero,
+        fundReceiver.getAddress(),
       );
       await erc721M.deployed();
 
@@ -198,11 +201,12 @@ describe('ERC721M: Mint Currency', () => {
 });
 
 describe('ERC721CM: Mint Currency', () => {
-  let erc721CM: ERC721CM,
-    contract: ERC721CM,
-    erc20: Contract,
-    owner: Signer,
-    minter: Signer;
+  let erc721CM: ERC721CM;
+  let contract: ERC721CM;
+  let erc20: Contract;
+  let owner: Signer;
+  let fundReceiver: Signer;
+  let minter: Signer;
   const mintPrice = 50;
   const mintFee = 10;
   const mintQty = 3;
@@ -210,6 +214,8 @@ describe('ERC721CM: Mint Currency', () => {
 
   describe('deployed with ERC-20 token as mint currency', function () {
     beforeEach(async function () {
+      [owner, minter, fundReceiver] = await ethers.getSigners();
+
       // Deploy the ERC20 token contract that will be used for minting
       const Token = await ethers.getContractFactory('MockERC20');
       erc20 = await Token.deploy(10000);
@@ -226,10 +232,9 @@ describe('ERC721CM: Mint Currency', () => {
         ethers.constants.AddressZero,
         60,
         erc20.address,
+        fundReceiver.getAddress(),
       );
       await erc721CM.deployed();
-
-      [owner, minter] = await ethers.getSigners();
 
       contract = erc721CM.connect(owner);
 
@@ -332,11 +337,10 @@ describe('ERC721CM: Mint Currency', () => {
         // Then, call the withdrawERC20 function from the owner's account
         await erc721CM.connect(owner).withdrawERC20();
 
-        // Get the owner's balance
-        const ownerBalance = await erc20.balanceOf(await owner.getAddress());
+        // Get the fundReceiver's balance
+        const fundReceiverBalance = await erc20.balanceOf(await fundReceiver.getAddress());
 
-        // The owner's balance should now be equal to the initial amount
-        expect(ownerBalance).to.equal(initialAmount);
+        expect(fundReceiverBalance).to.equal(initialAmount);
       });
     });
 
@@ -350,6 +354,8 @@ describe('ERC721CM: Mint Currency', () => {
 
   describe('deployed with zero address as mint currency', function () {
     beforeEach(async function () {
+      [owner, minter, fundReceiver] = await ethers.getSigners();
+
       // Deploy the ERC721M contract
       const ERC721CM = await ethers.getContractFactory('ERC721CM');
       erc721CM = await ERC721CM.deploy(
@@ -361,10 +367,9 @@ describe('ERC721CM: Mint Currency', () => {
         ethers.constants.AddressZero,
         60,
         ethers.constants.AddressZero,
+        fundReceiver.getAddress(),
       );
       await erc721CM.deployed();
-
-      [owner, minter] = await ethers.getSigners();
 
       contract = erc721CM.connect(owner);
     });


### PR DESCRIPTION
- Allow deployer assign `FUND_RECEIVER` during construction
- If not explicitly set, `FUND_RECEIVER` is set to contract deployer
- `withdraw` and `withdrawERC20` sends fund to `FUND_RECEIVER`

<img width="712" alt="image" src="https://github.com/magicoss/erc721m/assets/95395274/61cddd33-a887-4ab7-a103-9455faa533b6">
